### PR TITLE
feat: job-store APIにtotalCount機能を追加

### DIFF
--- a/packages/job-store/src/clientImpl/adapter.ts
+++ b/packages/job-store/src/clientImpl/adapter.ts
@@ -37,7 +37,11 @@ export const createJobStoreDBClientAdapter = (
     cursor?: { jobId: number };
     limit: number;
     filter?: { companyName?: string };
-  }): Promise<{ jobs: Job[]; cursor: { jobId: number } }> => {
+  }): Promise<{
+    jobs: Job[];
+    cursor: { jobId: number };
+    meta: { totalCount: number };
+  }> => {
     const { cursor, limit, filter = {} } = options;
 
     const conditions = [];
@@ -57,10 +61,18 @@ export const createJobStoreDBClientAdapter = (
         ? await query.where(and(...conditions)).limit(limit)
         : await query.limit(limit);
 
+    const totalCount = await drizzleClient.$count(
+      jobs,
+      conditions.length > 0 ? and(...conditions) : undefined,
+    );
+
     return {
       jobs: jobList,
       cursor: {
         jobId: jobList.length > 0 ? jobList[jobList.length - 1].id : 1,
+      },
+      meta: {
+        totalCount,
       },
     };
   },

--- a/packages/models/src/schemas/job-store/jobList.ts
+++ b/packages/models/src/schemas/job-store/jobList.ts
@@ -30,6 +30,9 @@ export const JobListSchema = z.array(
 export const jobListSuccessResponseSchema = z.object({
   jobs: JobListSchema,
   nextToken: z.string().optional(),
+  meta: z.object({
+    totalCount: z.number(),
+  }),
 });
 
 export const jobListClientErrorResponseSchema = z.object({

--- a/packages/models/src/types/job-store/client.ts
+++ b/packages/models/src/types/job-store/client.ts
@@ -10,6 +10,10 @@ export type JobStoreDBClient = {
     cursor?: { jobId: number };
     limit: number;
     filter?: { companyName?: string };
-  }) => Promise<{ jobs: Job[]; cursor: { jobId: number } }>;
+  }) => Promise<{
+    jobs: Job[];
+    cursor: { jobId: number };
+    meta: { totalCount: number };
+  }>;
   checkJobExists: (jobNumber: string) => Promise<boolean>;
 };


### PR DESCRIPTION
- `findJobs`メソッドの戻り値型に`meta: { totalCount: number }`を追加
- `drizzleClient.$count()`を使用して総件数を取得する処理を実装
- フィルター条件がある場合は同じ条件で件数をカウント

- `JobStoreDBClient`の`findJobs`メソッドの戻り値型を更新
- `Promise<{ jobs: Job[]; cursor: { jobId: number }, meta: { totalCount: number } }>`に変更

- `jobListSuccessResponseSchema`に`meta`オブジェクトを追加
- `meta: z.object({ totalCount: z.number() })`でスキーマ定義

- job-store APIのレスポンス形式が変更されるため、フロントエンド側での対応が必要
- ページネーション機能において総件数の表示が可能になる

- Drizzle ORMの`$count`メソッドを使用してパフォーマンスを考慮した件数取得を実装
- 既存のフィルター条件（会社名検索など）と同じ条件で件数をカウント