### PR TITLE
refactor(job-store, models): migrate zod to valibot and chanfana to h…

### DIFF
--- a/apps/hello-work-job-searcher/package.json
+++ b/apps/hello-work-job-searcher/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack -p 9002",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@sho/models": "workspace:*",
@@ -15,7 +16,8 @@
     "neverthrow": "^8.2.0",
     "next": "15.5.2",
     "react": "19.1.1",
-    "react-dom": "19.1.1"
+    "react-dom": "19.1.1",
+    "valibot": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/apps/hello-work-job-searcher/src/app/jobs/[jobNumber]/page.tsx
+++ b/apps/hello-work-job-searcher/src/app/jobs/[jobNumber]/page.tsx
@@ -1,4 +1,5 @@
 import { jobFetchSuccessResponseSchema } from "@sho/models";
+import * as v from "valibot";
 import { JobDetail } from "@/app/components/Job";
 import styles from "./page.module.css";
 
@@ -16,7 +17,7 @@ export default async function Page({ params }: PageProps) {
   const data = await fetch(`${endpoint}/job/${jobNumber}`).then((res) =>
     res.json(),
   );
-  const validatedData = jobFetchSuccessResponseSchema.parse(data);
+  const validatedData = v.parse(jobFetchSuccessResponseSchema, data);
   const jobDetail = {
     ...validatedData,
     workingHours: `${validatedData.workingStartTime}〜${validatedData.workingEndTime}`,

--- a/apps/hello-work-job-searcher/src/app/store/client/index.ts
+++ b/apps/hello-work-job-searcher/src/app/store/client/index.ts
@@ -1,5 +1,6 @@
 import { jobListSuccessResponseSchema, type SearchFilter } from "@sho/models";
 import { err, ok, okAsync, ResultAsync, safeTry } from "neverthrow";
+import * as v from "valibot";
 import type { JobStoreClient } from "../type";
 
 export const jobStoreClientOnBrowser: JobStoreClient = {
@@ -38,11 +39,11 @@ export const jobStoreClientOnBrowser: JobStoreClient = {
       );
 
       const validatedData = yield* (() => {
-        const result = jobListSuccessResponseSchema.safeParse(data);
+        const result = v.safeParse(jobListSuccessResponseSchema, data);
         if (!result.success) {
-          return err(new Error(`Invalid job data: ${result.error.message}`));
+          return err(new Error(`Invalid job data: ${result.issues}`));
         }
-        return ok(result.data);
+        return ok(result.output);
       })();
       return okAsync(validatedData);
     });
@@ -59,11 +60,11 @@ export const jobStoreClientOnBrowser: JobStoreClient = {
       );
 
       const validatedData = yield* (() => {
-        const result = jobListSuccessResponseSchema.safeParse(data);
+        const result = v.safeParse(jobListSuccessResponseSchema, data);
         if (!result.success) {
-          return err(new Error(`Invalid job data: ${result.error.message}`));
+          return err(new Error(`Invalid job data: ${result.issues}`));
         }
-        return ok(result.data);
+        return ok(result.output);
       })();
       return okAsync(validatedData);
     });

--- a/apps/hello-work-job-searcher/src/app/store/server/index.ts
+++ b/apps/hello-work-job-searcher/src/app/store/server/index.ts
@@ -1,5 +1,6 @@
 import { jobListSuccessResponseSchema, type SearchFilter } from "@sho/models";
 import { err, ok, okAsync, ResultAsync, safeTry } from "neverthrow";
+import * as v from "valibot";
 import type { JobStoreClient } from "../type";
 
 const j = Symbol();
@@ -52,11 +53,11 @@ export const jobStoreClientOnServer: JobStoreClient = {
       );
 
       const validatedData = yield* (() => {
-        const result = jobListSuccessResponseSchema.safeParse(data);
+        const result = v.safeParse(jobListSuccessResponseSchema, data);
         if (!result.success) {
-          return err(new Error(`Invalid job data: ${result.error.message}`));
+          return err(new Error(`Invalid job data: ${result.issues}`));
         }
-        return ok(result.data);
+        return ok(result.output);
       })();
       return okAsync(validatedData);
     });
@@ -84,11 +85,11 @@ export const jobStoreClientOnServer: JobStoreClient = {
       );
 
       const validatedData = yield* (() => {
-        const result = jobListSuccessResponseSchema.safeParse(data);
+        const result = v.safeParse(jobListSuccessResponseSchema, data);
         if (!result.success) {
-          return err(new Error(`Invalid job data: ${result.error.message}`));
+          return err(new Error(`Invalid job data: ${result.issues}`));
         }
-        return ok(result.data);
+        return ok(result.output);
       })();
       return okAsync(validatedData);
     });

--- a/apps/hello-work-job-searcher/src/app/store/type.ts
+++ b/apps/hello-work-job-searcher/src/app/store/type.ts
@@ -1,6 +1,6 @@
 import type { jobListSuccessResponseSchema, SearchFilter } from "@sho/models";
 import type { ResultAsync } from "neverthrow";
-
+import type { InferOutput } from "valibot";
 /**
  * 求人ストアクライアントの共通インターフェース
  */
@@ -11,7 +11,7 @@ export interface JobStoreClient {
    */
   getInitialJobs(
     filter?: SearchFilter,
-  ): ResultAsync<ReturnType<typeof jobListSuccessResponseSchema.parse>, Error>;
+  ): ResultAsync<InferOutput<typeof jobListSuccessResponseSchema>, Error>;
 
   /**
    * 続きの求人リスト取得
@@ -19,5 +19,5 @@ export interface JobStoreClient {
    */
   getContinuedJobs(
     nextToken: string,
-  ): ResultAsync<ReturnType<typeof jobListSuccessResponseSchema.parse>, Error>;
+  ): ResultAsync<InferOutput<typeof jobListSuccessResponseSchema>, Error>;
 }

--- a/packages/headless-crawler/lib/functions/jobQueueHandler/helper.ts
+++ b/packages/headless-crawler/lib/functions/jobQueueHandler/helper.ts
@@ -10,6 +10,7 @@ import {
   transformedWorkingHoursSchema,
 } from "@sho/models";
 import { Effect, Schema } from "effect";
+import * as v from "valibot";
 import {
   GetEndPointError,
   InsertJobError,
@@ -190,7 +191,7 @@ export function buildJobStoreClient() {
 export function validateInsertJobSuccessResponse(val: unknown) {
   return Effect.try({
     try: () => {
-      insertJobSuccessResponseSchema.parse(val);
+      v.parse(insertJobSuccessResponseSchema, val);
     },
     catch: (e) =>
       new InsertJobSuccessResponseValidationError({

--- a/packages/headless-crawler/package.json
+++ b/packages/headless-crawler/package.json
@@ -19,8 +19,7 @@
     "aws-cdk": "2.1027.0",
     "esbuild": "^0.25.5",
     "ts-node": "^10.9.2",
-    "typescript": "~5.8.0",
-    "zod": "^3.25.74"
+    "typescript": "~5.8.0"
   },
   "dependencies": {
     "@aws-sdk/client-sqs": "^3.840.0",
@@ -29,6 +28,8 @@
     "constructs": "^10.0.0",
     "dotenv": "^17.0.0",
     "effect": "^3.16.5",
-    "playwright": "^1.53.1"
+    "playwright": "^1.53.1",
+    "valibot": "^1.1.0",
+    "zod": "^4.1.5"
   }
 }

--- a/packages/job-store/package.json
+++ b/packages/job-store/package.json
@@ -10,6 +10,7 @@
 		"start": "wrangler dev",
 		"test": "vitest",
 		"cf-typegen": "wrangler types",
+		"type-check": "tsc --noEmit",
 		"copy-schema": "pnpm exec copy-schema ./src/db/schema.ts"
 	},
 	"devDependencies": {
@@ -24,16 +25,16 @@
 		"wrangler": "^4.26.1"
 	},
 	"dependencies": {
-		"@hono/zod-openapi": "^1.0.2",
-		"@hono/zod-validator": "^0.7.2",
+		"@hono/swagger-ui": "^0.5.2",
+		"@hono/valibot-validator": "^0.5.3",
 		"@sho/models": "workspace:*",
 		"@sho/scripts": "workspace:*",
+		"@valibot/to-json-schema": "^1.3.0",
 		"chanfana": "^2.8.1",
 		"dotenv": "^17.0.0",
 		"hono": "^4.8.3",
 		"hono-openapi": "^0.4.8",
 		"neverthrow": "^8.2.0",
-		"valibot": "^1.1.0",
-		"zod": "~3.25.74"
+		"valibot": "^1.1.0"
 	}
 }

--- a/packages/job-store/src/db/schema.ts
+++ b/packages/job-store/src/db/schema.ts
@@ -1,5 +1,5 @@
 import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
-import z from "zod";
+import { nullable, number, object, string } from "valibot";
 
 export const jobs = sqliteTable("jobs", {
   id: integer("id").primaryKey({ autoIncrement: true }),
@@ -24,24 +24,24 @@ export const jobs = sqliteTable("jobs", {
 });
 
 // これ、キーしか型チェック指定なので、かなりfreaky
-export const jobSelectSchema = z.object({
-  id: z.number().int(),
-  jobNumber: z.string(),
-  companyName: z.string(),
-  receivedDate: z.string(),
-  expiryDate: z.string(),
-  homePage: z.string().nullable(),
-  occupation: z.string(),
-  employmentType: z.string(),
-  wageMin: z.number().int(),
-  wageMax: z.number().int(),
-  workingStartTime: z.string().nullable(),
-  workingEndTime: z.string().nullable(),
-  employeeCount: z.number(),
-  workPlace: z.string().nullable(),
-  jobDescription: z.string().nullable(),
-  qualifications: z.string().nullable(),
-  status: z.string(),
-  createdAt: z.string(),
-  updatedAt: z.string(),
+export const jobSelectSchema = object({
+  id: number(),
+  jobNumber: string(),
+  companyName: string(),
+  receivedDate: string(),
+  expiryDate: string(),
+  homePage: nullable(string()),
+  occupation: string(),
+  employmentType: string(),
+  wageMin: number(),
+  wageMax: number(),
+  workingStartTime: nullable(string()),
+  workingEndTime: nullable(string()),
+  employeeCount: number(),
+  workPlace: nullable(string()),
+  jobDescription: nullable(string()),
+  qualifications: nullable(string()),
+  status: string(),
+  createdAt: string(),
+  updatedAt: string(),
 });

--- a/packages/job-store/src/endpoint/error.ts
+++ b/packages/job-store/src/endpoint/error.ts
@@ -15,9 +15,19 @@ export type JWTSignatureError = {
   readonly message: string;
 };
 
+export type EnvError = {
+  readonly _tag: "EnvError";
+  readonly message: string;
+};
+
 export const createJWTSignatureError = (
   message: string,
 ): JWTSignatureError => ({
   _tag: "JWTSignatureError",
+  message,
+});
+
+export const createEnvError = (message: string): EnvError => ({
+  _tag: "EnvError",
   message,
 });

--- a/packages/job-store/src/endpoint/jobInsert/jobInsert.ts
+++ b/packages/job-store/src/endpoint/jobInsert/jobInsert.ts
@@ -1,72 +1,36 @@
 import {
   insertJobClientErrorResponseSchema,
-  insertJobRequestBodySchema,
   insertJobServerErrorResponseSchema,
   insertJobSuccessResponseSchema,
 } from "@sho/models";
-import { contentJson, OpenAPIRoute } from "chanfana";
-import { HTTPException } from "hono/http-exception";
-import { okAsync, ResultAsync, safeTry } from "neverthrow";
-import type { AppContext } from "../../app";
-import { createJobStoreResultBuilder } from "../../clientImpl";
-import { createJobStoreDBClientAdapter } from "../../clientImpl/adapter";
-import { getDb } from "../../db";
-import { createFetchValidationError } from "../jobFetch/error";
+import { describeRoute } from "hono-openapi";
+import { resolver } from "hono-openapi/valibot";
 
-export class JobInsertEndpoint extends OpenAPIRoute {
-  schema = {
-    request: {
-      body: {
-        ...contentJson(insertJobRequestBodySchema),
+export const jobInsertRoute = describeRoute({
+  responses: {
+    "200": {
+      description: "Successful response",
+      content: {
+        "application/json": {
+          schema: resolver(insertJobSuccessResponseSchema),
+        },
       },
     },
-    responses: {
-      "200": {
-        description: "Successful response",
-        ...contentJson(insertJobSuccessResponseSchema),
-      },
-      "400": {
-        description: "client error response",
-        ...contentJson(insertJobClientErrorResponseSchema),
-      },
-      "500": {
-        description: "internal server error response",
-        ...contentJson(insertJobServerErrorResponseSchema),
+    "400": {
+      description: "client error response",
+      content: {
+        "application/json": {
+          schema: resolver(insertJobClientErrorResponseSchema),
+        },
       },
     },
-  };
-
-  async handle(c: AppContext) {
-    const self = this;
-    // バリデーション
-    const result = safeTry(async function* () {
-      const validatedData = yield* await ResultAsync.fromPromise(
-        self.getValidatedData<typeof self.schema>(),
-        (error) =>
-          createFetchValidationError(`Validation failed: ${String(error)}`),
-      );
-      const { body } = validatedData;
-      const db = getDb(c);
-      const dbClient = createJobStoreDBClientAdapter(db);
-      const jobStore = createJobStoreResultBuilder(dbClient);
-      const job = yield* await jobStore.insertJob(body);
-      return okAsync(job);
-    });
-    return result.match(
-      (job) => c.json(job),
-      (error) => {
-        console.error(error);
-
-        switch (error._tag) {
-          case "InsertJobError":
-            throw new HTTPException(500, { message: error.message });
-          case "InsertJobDuplicationError":
-          case "FetchJobValidationError":
-            throw new HTTPException(400, { message: error.message });
-          default:
-            throw new HTTPException(500, { message: "Unknown error occurred" });
-        }
+    "500": {
+      description: "internal server error response",
+      content: {
+        "application/json": {
+          schema: resolver(insertJobServerErrorResponseSchema),
+        },
       },
-    );
-  }
-}
+    },
+  },
+});

--- a/packages/job-store/src/endpoint/jobList/continue/index.ts
+++ b/packages/job-store/src/endpoint/jobList/continue/index.ts
@@ -1,152 +1,36 @@
 import {
-  type DecodedNextToken,
-  decodedNextTokenSchema,
   jobListContinueClientErrorResponseSchema,
-  jobListContinueQuerySchema,
   jobListContinueServerErrorSchema,
   jobListSuccessResponseSchema,
 } from "@sho/models";
-import { contentJson, OpenAPIRoute } from "chanfana";
-import { HTTPException } from "hono/http-exception";
-import { decode, sign } from "hono/jwt";
-import { errAsync, okAsync, ResultAsync, safeTry } from "neverthrow";
-import type { AppContext } from "../../../app";
-import { createJobStoreResultBuilder } from "../../../clientImpl";
-import { createJobStoreDBClientAdapter } from "../../../clientImpl/adapter";
-import { getDb } from "../../../db";
-import {
-  createJWTSignatureError,
-  createSchemaValidationError,
-} from "../../error";
-import {
-  createDecodeJWTPayloadError,
-  createJWTDecodeError,
-  createJWTExpiredError,
-} from "./error";
+import { describeRoute } from "hono-openapi";
+import { resolver } from "hono-openapi/valibot";
 
-export class JobListContinueEndpoint extends OpenAPIRoute {
-  schema = {
-    request: {
-      query: jobListContinueQuerySchema,
-    },
-    responses: {
-      "200": {
-        description: "Successful response",
-        ...contentJson(jobListSuccessResponseSchema),
-      },
-      "400": {
-        description: "client error response",
-        ...contentJson(jobListContinueClientErrorResponseSchema),
-      },
-      "500": {
-        description: "internal server error response",
-        ...contentJson(jobListContinueServerErrorSchema),
+export const jobListContinueRoute = describeRoute({
+  responses: {
+    "200": {
+      description: "Successful response",
+      content: {
+        "application/json": {
+          schema: resolver(jobListSuccessResponseSchema),
+        },
       },
     },
-  };
-
-  async handle(c: AppContext) {
-    const self = this;
-    const result = safeTry(async function* () {
-      // バリデーション
-      const validatedData = yield* await ResultAsync.fromPromise(
-        self.getValidatedData<typeof self.schema>(),
-        (error) =>
-          createSchemaValidationError(
-            `Fetch JobListContinue validation failed\n${String(error)}`,
-          ),
-      );
-
-      const {
-        query: { nextToken },
-      } = validatedData;
-
-      const jwtSecret = c.env.JWT_SECRET;
-
-      const db = getDb(c);
-      const dbClient = createJobStoreDBClientAdapter(db); // DrizzleをJobStoreDBClientに変換
-      const jobStore = createJobStoreResultBuilder(dbClient);
-
-      const decodeResult = yield* ResultAsync.fromPromise(
-        Promise.resolve(decode(nextToken)),
-        (error) =>
-          createJWTDecodeError(`JWT decoding failed.\n${String(error)}`),
-      );
-      const payloadValidation = decodedNextTokenSchema.safeParse(
-        decodeResult.payload,
-      );
-      if (!payloadValidation.success) {
-        return errAsync(
-          createDecodeJWTPayloadError(
-            `Decoding JWT payload failed.\n${String(payloadValidation.error)}`,
-          ),
-        );
-      }
-      const validatedPayload = payloadValidation.data;
-
-      // JWT有効期限チェック
-      const now = Math.floor(Date.now() / 1000);
-      if (validatedPayload.exp && validatedPayload.exp < now) {
-        return errAsync(createJWTExpiredError("JWT expired"));
-      }
-
-      const limit = 20;
-      // ジョブリスト取得
-      const jobListResult = yield* await jobStore.fetchJobList({
-        cursor: { jobId: validatedPayload.cursor.jobId },
-        limit,
-        filter: validatedPayload.filter,
-      });
-
-      const {
-        jobs,
-        cursor: { jobId },
-        meta,
-      } = jobListResult;
-
-      const { count: restJobCount } = yield* await jobStore.countJobs({
-        cursor: { jobId },
-        filter: meta.filter,
-      });
-
-      const newNextToken = yield* (() => {
-        if (restJobCount <= limit) return okAsync(undefined);
-        const validPayload: DecodedNextToken = {
-          exp: Math.floor(Date.now() / 1000) + 60 * 15, // 15分後の有効期限
-          cursor: { jobId },
-          filter: meta.filter,
-        };
-        const signResult = ResultAsync.fromPromise(
-          sign(validPayload, jwtSecret),
-          (error) =>
-            createJWTSignatureError(`JWT signing failed.\n${String(error)}`),
-        );
-        return signResult;
-      })();
-
-      return okAsync({ jobs, nextToken: newNextToken, meta });
-    });
-
-    return result.match(
-      ({ jobs, nextToken, meta }) => c.json({ jobs, nextToken, meta }),
-      (error) => {
-        console.error(error);
-
-        switch (error._tag) {
-          case "JWTDecodeError":
-            throw new HTTPException(400, { message: "invalid nextToken" });
-          case "JWTSignatureError":
-            throw new HTTPException(500, { message: error.message });
-          case "JWTExpiredError":
-            throw new HTTPException(401, { message: "nextToken expired" });
-          case "DecodeJWTPayloadError":
-            throw new HTTPException(400, { message: "invalid nextToken" });
-          case "ResponseSchemaValidationError":
-            throw new HTTPException(400, { message: "invalid query" });
-          default:
-            throw new HTTPException(500, { message: "internal server error" });
-        }
+    "400": {
+      description: "client error response",
+      content: {
+        "application/json": {
+          schema: resolver(jobListContinueClientErrorResponseSchema),
+        },
       },
-    );
-  }
-}
+    },
+    "500": {
+      description: "internal server error response",
+      content: {
+        "application/json": {
+          schema: resolver(jobListContinueServerErrorSchema),
+        },
+      },
+    },
+  },
+});

--- a/packages/job-store/src/endpoint/jobList/index.ts
+++ b/packages/job-store/src/endpoint/jobList/index.ts
@@ -1,139 +1,36 @@
-import type { DecodedNextToken } from "@sho/models";
 import {
   jobListClientErrorResponseSchema,
-  jobListQuerySchema,
   jobListServerErrorSchema,
   jobListSuccessResponseSchema,
 } from "@sho/models";
-import { contentJson, OpenAPIRoute } from "chanfana";
-import { HTTPException } from "hono/http-exception";
-import { sign } from "hono/jwt";
-import { okAsync, ResultAsync, safeTry } from "neverthrow";
-import type { AppContext } from "../../app";
-import { createJobStoreResultBuilder } from "../../clientImpl";
-import { createJobStoreDBClientAdapter } from "../../clientImpl/adapter";
-import { getDb } from "../../db";
-import { createJWTSignatureError, createSchemaValidationError } from "../error";
+import { describeRoute } from "hono-openapi";
+import { resolver } from "hono-openapi/valibot";
 
-const INITIAL_JOB_ID = 1; // 初期のcursorとして使用するjobId
-
-export class JobListEndpoint extends OpenAPIRoute {
-  schema = {
-    request: {
-      query: jobListQuerySchema,
-    },
-    responses: {
-      "200": {
-        description: "Successful response",
-        ...contentJson(jobListSuccessResponseSchema),
-      },
-      "400": {
-        description: "client error response",
-        ...contentJson(jobListClientErrorResponseSchema),
-      },
-      "500": {
-        description: "internal server error response",
-        ...contentJson(jobListServerErrorSchema),
+export const jobListRoute = describeRoute({
+  responses: {
+    "200": {
+      description: "Successful response",
+      content: {
+        "application/json": {
+          schema: resolver(jobListSuccessResponseSchema),
+        },
       },
     },
-  };
-
-  async handle(c: AppContext) {
-    const self = this;
-    const result = safeTry(async function* () {
-      const validatedData = yield* await ResultAsync.fromPromise(
-        self.getValidatedData<typeof self.schema>(),
-        (error) =>
-          createSchemaValidationError(
-            `Fetch JobList validation failed\n${String(error)}`,
-          ),
-      );
-
-      const {
-        query: {
-          companyName: encodedCompanyName,
-          employeeCountGt,
-          employeeCountLt,
-          jobDescription: encodedJobDescription,
-          jobDescriptionExclude: encodedJobDescriptionExclude,
-          onlyNotExpired,
+    "400": {
+      description: "client error response",
+      content: {
+        "application/json": {
+          schema: resolver(jobListClientErrorResponseSchema),
         },
-      } = validatedData;
-
-      const companyName = encodedCompanyName
-        ? decodeURIComponent(encodedCompanyName)
-        : undefined;
-      const jobDescription = encodedJobDescription
-        ? decodeURIComponent(encodedJobDescription)
-        : undefined;
-
-      const jobDescriptionExclude = encodedJobDescriptionExclude
-        ? decodeURIComponent(encodedJobDescriptionExclude)
-        : undefined;
-
-      const jwtSecret = c.env.JWT_SECRET;
-
-      const db = getDb(c);
-      const dbClient = createJobStoreDBClientAdapter(db);
-      const jobStore = createJobStoreResultBuilder(dbClient);
-
-      const limit = 20;
-      const jobListResult = yield* await jobStore.fetchJobList({
-        cursor: { jobId: INITIAL_JOB_ID },
-        limit,
-        filter: {
-          companyName,
-          employeeCountGt,
-          employeeCountLt,
-          jobDescription,
-          jobDescriptionExclude,
-          onlyNotExpired,
-        },
-      });
-
-      const {
-        jobs,
-        cursor: { jobId },
-        meta,
-      } = jobListResult;
-
-      const { count: restJobCount } = yield* await jobStore.countJobs({
-        cursor: { jobId },
-        filter: meta.filter,
-      });
-
-      const nextToken = yield* (() => {
-        if (restJobCount <= limit) return okAsync(undefined);
-        const validPayload: DecodedNextToken = {
-          exp: Math.floor(Date.now() / 1000) + 60 * 15, // 15分後の有効期限
-          cursor: { jobId },
-          filter: meta.filter,
-        };
-        const signResult = ResultAsync.fromPromise(
-          sign(validPayload, jwtSecret),
-          (error) =>
-            createJWTSignatureError(`JWT signing failed.\n${String(error)}`),
-        );
-        return signResult;
-      })();
-
-      return okAsync({ jobs, nextToken, meta });
-    });
-
-    return await result.match(
-      ({ jobs, nextToken, meta }) => c.json({ jobs, nextToken, meta }),
-      (error) => {
-        console.error(error);
-
-        switch (error._tag) {
-          case "JWTSignatureError":
-            throw new HTTPException(500, { message: error.message });
-          case "ResponseSchemaValidationError":
-            throw new HTTPException(400, { message: error.message });
-          default:
-            throw new HTTPException(500, { message: "internal server error" });
-        }
       },
-    );
-  }
-}
+    },
+    "500": {
+      description: "internal server error response",
+      content: {
+        "application/json": {
+          schema: resolver(jobListServerErrorSchema),
+        },
+      },
+    },
+  },
+});

--- a/packages/job-store/wrangler.jsonc
+++ b/packages/job-store/wrangler.jsonc
@@ -10,6 +10,7 @@
   "observability": {
     "enabled": true
   },
+  "compatibility_flags": ["nodejs_compat"],
   /**
    * Smart Placement
    * Docs: https://developers.cloudflare.com/workers/configuration/smart-placement/#smart-placement

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -9,12 +9,13 @@
     }
   },
   "scripts": {
-    "build": "tsup"
+    "build": "tsup",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@asteasolutions/zod-to-openapi": "^7.2.0",
     "drizzle-orm": "^0.44.2",
-    "zod": "^3.25.74"
+    "valibot": "^1.1.0",
+    "zod": "^4.1.5"
   },
   "devDependencies": {
     "playwright": "^1.53.1",

--- a/packages/models/src/schemas/headless-crawler/scraper.ts
+++ b/packages/models/src/schemas/headless-crawler/scraper.ts
@@ -131,7 +131,7 @@ export const transformedEmployeeCountSchema = RawEmployeeCountSchema.transform(
   .pipe(
     z
       .number({
-        invalid_type_error: "Failed to convert to a number",
+        // invalid_type_error: "Failed to convert to a number",
       })
       .int("Must be an integer")
       .nonnegative("Must be a non-negative number"),

--- a/packages/models/src/schemas/job-store/drizzle.ts
+++ b/packages/models/src/schemas/job-store/drizzle.ts
@@ -1,5 +1,5 @@
 import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
-import z from "zod";
+import { nullable, number, object, string } from "valibot";
 
 export const jobs = sqliteTable("jobs", {
   id: integer("id").primaryKey({ autoIncrement: true }),
@@ -24,24 +24,24 @@ export const jobs = sqliteTable("jobs", {
 });
 
 // これ、キーしか型チェック指定なので、かなりfreaky
-export const jobSelectSchema = z.object({
-  id: z.number().int(),
-  jobNumber: z.string(),
-  companyName: z.string(),
-  receivedDate: z.string(),
-  expiryDate: z.string(),
-  homePage: z.string().nullable(),
-  occupation: z.string(),
-  employmentType: z.string(),
-  wageMin: z.number().int(),
-  wageMax: z.number().int(),
-  workingStartTime: z.string().nullable(),
-  workingEndTime: z.string().nullable(),
-  employeeCount: z.number(),
-  workPlace: z.string().nullable(),
-  jobDescription: z.string().nullable(),
-  qualifications: z.string().nullable(),
-  status: z.string(),
-  createdAt: z.string(),
-  updatedAt: z.string(),
+export const jobSelectSchema = object({
+  id: number(),
+  jobNumber: string(),
+  companyName: string(),
+  receivedDate: string(),
+  expiryDate: string(),
+  homePage: nullable(string()),
+  occupation: string(),
+  employmentType: string(),
+  wageMin: number(),
+  wageMax: number(),
+  workingStartTime: nullable(string()),
+  workingEndTime: nullable(string()),
+  employeeCount: number(),
+  workPlace: nullable(string()),
+  jobDescription: nullable(string()),
+  qualifications: nullable(string()),
+  status: string(),
+  createdAt: string(),
+  updatedAt: string(),
 });

--- a/packages/models/src/schemas/job-store/jobFetch.ts
+++ b/packages/models/src/schemas/job-store/jobFetch.ts
@@ -1,26 +1,27 @@
-// https://github.com/cloudflare/chanfana/issues/167#issue-2470366210
-// paramでinternal server errorが出るので、zod-to-openapiを使う
-import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
-import z from "zod";
-import { jobNumberSchema } from "../headless-crawler";
+import { brand, object, pipe, regex, string } from "valibot";
+
+const jobNumberSchema = pipe(
+  string(),
+  regex(/^\d{5}-\d{0,8}$/, "jobNumber format invalid."),
+  brand("jobNumber"),
+);
+
 import { jobSelectSchema } from "./drizzle";
 
-extendZodWithOpenApi(z);
-
-export const jobFetchParamSchema = z.object({
+export const jobFetchParamSchema = object({
   jobNumber: jobNumberSchema,
 });
 
-export const JobSchema = jobSelectSchema.omit({
-  id: true,
-});
+// Valibotでomitはスプレッドで除外
+const { id: _, ...jobSelectSchemaWithoutId } = jobSelectSchema.entries;
+export const JobSchema = object({ ...jobSelectSchemaWithoutId });
 
 export const jobFetchSuccessResponseSchema = JobSchema;
 
-export const jobFetchClientErrorResponseSchema = z.object({
-  message: z.string(),
+export const jobFetchClientErrorResponseSchema = object({
+  message: string(),
 });
 
-export const jobFetchServerErrorSchema = z.object({
-  message: z.string(),
+export const jobFetchServerErrorSchema = object({
+  message: string(),
 });

--- a/packages/models/src/schemas/job-store/jobInsert.ts
+++ b/packages/models/src/schemas/job-store/jobInsert.ts
@@ -1,40 +1,97 @@
-import z from "zod";
-import { ScrapedJobSchema } from "../headless-crawler";
+import { literal, number, object, omit, regex, string } from "valibot";
+
 const ISO8601 =
-  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[\+\-]\d{2}:\d{2})$/;
-export const insertJobRequestBodySchema = ScrapedJobSchema.omit({
-  wage: true,
-  receivedDate: true,
-  workingHours: true,
-  employeeCount: true,
-}).extend({
-  wageMin: z.number(),
-  wageMax: z.number(),
-  workingStartTime: z.string(),
-  workingEndTime: z.string(),
-  receivedDate: z.string().regex(ISO8601),
-  expiryDate: z.string().regex(ISO8601),
-  employeeCount: z.number(),
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+import { nullable, pipe } from "valibot";
+
+const jobNumberSchema = pipe(
+  string(),
+  regex(/^\d{5}-\d{0,8}$/, "jobNumber format invalid."),
+);
+const companyNameSchema = string();
+const homePageSchema = pipe(
+  string(),
+  regex(/^https?:\/\//, "home page should be url"),
+);
+const occupationSchema = pipe(
+  string(),
+  regex(/^.+$/, "occupation should not be empty."),
+);
+const employmentTypeSchema = pipe(
+  string(),
+  regex(/^(正社員|パート労働者|正社員以外|有期雇用派遣労働者)$/),
+);
+const RawReceivedDateSchema = pipe(
+  string(),
+  regex(
+    /^\d{4}年\d{1,2}月\d{1,2}日$/,
+    "received date format invalid. should be yyyy年mm月dd日",
+  ),
+);
+const RawExpiryDateSchema = pipe(
+  string(),
+  regex(
+    /^\d{4}年\d{1,2}月\d{1,2}日$/,
+    "expiry date format invalid. should be yyyy年mm月dd日",
+  ),
+);
+const RawWageSchema = pipe(string(), regex(/^.+$/, "wage should not be empty"));
+const RawWorkingHoursSchema = pipe(
+  string(),
+  regex(/^.+$/, "workingHours should not be empty."),
+);
+const workPlaceSchema = string();
+const jobDescriptionSchema = string();
+const qualificationsSchema = string();
+const RawEmployeeCountSchema = string();
+
+export const unbrandedScrapedJobSchema = object({
+  jobNumber: jobNumberSchema,
+  companyName: companyNameSchema,
+  receivedDate: RawReceivedDateSchema,
+  expiryDate: RawExpiryDateSchema,
+  homePage: nullable(homePageSchema),
+  occupation: occupationSchema,
+  employmentType: employmentTypeSchema,
+  employeeCount: RawEmployeeCountSchema,
+  wage: RawWageSchema,
+  workingHours: RawWorkingHoursSchema,
+  workPlace: workPlaceSchema,
+  jobDescription: jobDescriptionSchema,
+  qualifications: nullable(qualificationsSchema),
 });
 
-export const insertJobResponseBodySchema = insertJobRequestBodySchema.extend({
-  createdAt: z.string(), // 必要なら z.string().regex(ISO8601)
-  updatedAt: z.string(),
-  status: z.string(),
+export const insertJobRequestBodySchema = object({
+  ...omit(unbrandedScrapedJobSchema, ["wage", "workingHours"]).entries,
+  wageMin: number(),
+  wageMax: number(),
+  workingStartTime: string(),
+  workingEndTime: string(),
+  receivedDate: pipe(string(), regex(ISO8601)),
+  expiryDate: pipe(string(), regex(ISO8601)),
+  employeeCount: number(),
+});
+
+export const insertJobResponseBodySchema = object({
+  ...insertJobRequestBodySchema.entries,
+  createdAt: pipe(string(), regex(ISO8601)), // 必要なら pipe(string(), regex(ISO8601))
+  updatedAt: pipe(string(), regex(ISO8601)),
+  status: string(),
 });
 
 // API レスポンス用スキーマ
-export const insertJobSuccessResponseSchema = z.object({
-  success: z.literal(true),
-  result: z.object({
+export const insertJobSuccessResponseSchema = object({
+  success: literal(true),
+  result: object({
     job: insertJobResponseBodySchema,
   }),
 });
 
-export const insertJobClientErrorResponseSchema = z.object({
-  message: z.string(),
+export const insertJobClientErrorResponseSchema = object({
+  message: string(),
 });
 
-export const insertJobServerErrorResponseSchema = z.object({
-  message: z.string(),
+export const insertJobServerErrorResponseSchema = object({
+  message: string(),
 });

--- a/packages/models/src/schemas/job-store/jobList/continue/index.ts
+++ b/packages/models/src/schemas/job-store/jobList/continue/index.ts
@@ -1,27 +1,22 @@
-// https://github.com/cloudflare/chanfana/issues/167#issue-2470366210
-// queryでinternal server errorが出るので、zod-to-openapiを使う
-import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
-import z from "zod";
+import { number, object, string } from "valibot";
 import { jobListSearchFilterSchema } from "..";
 
-extendZodWithOpenApi(z);
-
-export const jobListContinueQuerySchema = z.object({
-  nextToken: z.string(),
+export const jobListContinueQuerySchema = object({
+  nextToken: string(),
 });
 
-export const decodedNextTokenSchema = z.object({
-  exp: z.number(),
-  cursor: z.object({
-    jobId: z.number(),
+export const decodedNextTokenSchema = object({
+  exp: number(),
+  cursor: object({
+    jobId: number(),
   }),
   filter: jobListSearchFilterSchema,
 });
 
-export const jobListContinueClientErrorResponseSchema = z.object({
-  message: z.string(),
+export const jobListContinueClientErrorResponseSchema = object({
+  message: string(),
 });
 
-export const jobListContinueServerErrorSchema = z.object({
-  message: z.string(),
+export const jobListContinueServerErrorSchema = object({
+  message: string(),
 });

--- a/packages/models/src/schemas/job-store/jobList/index.ts
+++ b/packages/models/src/schemas/job-store/jobList/index.ts
@@ -1,45 +1,35 @@
-// https://github.com/cloudflare/chanfana/issues/167#issue-2470366210
-// queryでinternal server errorが出るので、zod-to-openapiを使う
-import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
-import z from "zod";
+import { array, boolean, number, object, optional, string } from "valibot";
 import { jobSelectSchema } from "../drizzle";
 
-extendZodWithOpenApi(z);
-
-export const searchFilterSchema = z.object({
-  companyName: z.string().optional(),
-  employeeCountLt: z.number().optional(),
-  employeeCountGt: z.number().optional(),
-  jobDescription: z.string().optional(),
-  jobDescriptionExclude: z.string().optional(), // 除外キーワード
-  onlyNotExpired: z.boolean().optional(),
+export const searchFilterSchema = object({
+  companyName: optional(string()),
+  employeeCountLt: optional(number()),
+  employeeCountGt: optional(number()),
+  jobDescription: optional(string()),
+  jobDescriptionExclude: optional(string()), // 除外キーワード
+  onlyNotExpired: optional(boolean()),
 });
 
 export const jobListQuerySchema = searchFilterSchema;
 
 export const jobListSearchFilterSchema = searchFilterSchema;
 
-export const JobListSchema = z.array(
-  jobSelectSchema.omit({
-    id: true,
-    createdAt: true,
-    updatedAt: true,
-    status: true,
-  }),
-);
+const { id, createdAt, updatedAt, status, ...jobSelectSchemaWithoutSome } =
+  jobSelectSchema.entries;
+export const JobListSchema = array(object({ ...jobSelectSchemaWithoutSome }));
 
-export const jobListSuccessResponseSchema = z.object({
+export const jobListSuccessResponseSchema = object({
   jobs: JobListSchema,
-  nextToken: z.string().optional(),
-  meta: z.object({
-    totalCount: z.number(),
+  nextToken: optional(string()),
+  meta: object({
+    totalCount: number(),
   }),
 });
 
-export const jobListClientErrorResponseSchema = z.object({
-  message: z.string(),
+export const jobListClientErrorResponseSchema = object({
+  message: string(),
 });
 
-export const jobListServerErrorSchema = z.object({
-  message: z.string(),
+export const jobListServerErrorSchema = object({
+  message: string(),
 });

--- a/packages/models/src/types/job-store/client.ts
+++ b/packages/models/src/types/job-store/client.ts
@@ -1,4 +1,4 @@
-import type z from "zod";
+import type { InferOutput } from "valibot";
 import type { searchFilterSchema } from "../../schemas";
 import type { Job } from "./jobFetch";
 import type { InsertJobRequestBody } from "./jobInsert";
@@ -41,7 +41,7 @@ export type JobStoreCommand =
   | CountJobsCommand;
 
 // --- コマンドtypeごとのoutput型マッピング ---
-export type SearchFilter = z.infer<typeof searchFilterSchema>;
+export type SearchFilter = InferOutput<typeof searchFilterSchema>;
 export interface CommandOutputMap {
   InsertJob: { jobId: number };
   FindJobByNumber: { job: Job | null };

--- a/packages/models/src/types/job-store/drizzle.ts
+++ b/packages/models/src/types/job-store/drizzle.ts
@@ -1,4 +1,4 @@
-import type z from "zod";
+import type { InferOutput } from "valibot";
 import type { jobSelectSchema, jobs } from "../../schemas";
 
 // 🔍 型チェック用ユーティリティ
@@ -10,8 +10,8 @@ export type KeysMustMatch<A, B> = Exclude<keyof A, keyof B> extends never
 
 type JobSelectFromDrizzle = typeof jobs.$inferSelect;
 
-type JobSelectFromZod = z.infer<typeof jobSelectSchema>;
+type JobSelectFromValibot = InferOutput<typeof jobSelectSchema>;
 
-type Check = KeysMustMatch<JobSelectFromDrizzle, JobSelectFromZod>;
+type Check = KeysMustMatch<JobSelectFromDrizzle, JobSelectFromValibot>;
 // 一旦キーだけ比較してる
-const check: Check = true;
+const _check: Check = true;

--- a/packages/models/src/types/job-store/jobFetch.ts
+++ b/packages/models/src/types/job-store/jobFetch.ts
@@ -1,4 +1,4 @@
-import type z from "zod";
+import type { InferOutput } from "valibot";
 import type { JobSchema } from "../../schemas";
 
-export type Job = z.infer<typeof JobSchema>;
+export type Job = InferOutput<typeof JobSchema>;

--- a/packages/models/src/types/job-store/jobInsert.ts
+++ b/packages/models/src/types/job-store/jobInsert.ts
@@ -1,4 +1,6 @@
-import type z from "zod";
+import type { InferOutput } from "valibot";
 import type { insertJobRequestBodySchema } from "../../schemas";
 
-export type InsertJobRequestBody = z.infer<typeof insertJobRequestBodySchema>;
+export type InsertJobRequestBody = InferOutput<
+  typeof insertJobRequestBodySchema
+>;

--- a/packages/models/src/types/job-store/jobList.ts
+++ b/packages/models/src/types/job-store/jobList.ts
@@ -1,6 +1,6 @@
-import type z from "zod";
+import type { InferOutput } from "valibot";
 import type { decodedNextTokenSchema, JobListSchema } from "../../schemas";
 
-export type JobList = z.infer<typeof JobListSchema>;
+export type JobList = InferOutput<typeof JobListSchema>;
 
-export type DecodedNextToken = z.infer<typeof decodedNextTokenSchema>;
+export type DecodedNextToken = InferOutput<typeof decodedNextTokenSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       react-dom:
         specifier: 19.1.1
         version: 19.1.1(react@19.1.1)
+      valibot:
+        specifier: ^1.1.0
+        version: 1.1.0(typescript@5.9.2)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -91,6 +94,12 @@ importers:
       playwright:
         specifier: ^1.53.1
         version: 1.54.1
+      valibot:
+        specifier: ^1.1.0
+        version: 1.1.0(typescript@5.8.3)
+      zod:
+        specifier: ^4.1.5
+        version: 4.1.5
     devDependencies:
       '@sparticuz/chromium':
         specifier: ^138.0.0
@@ -116,24 +125,24 @@ importers:
       typescript:
         specifier: ~5.8.0
         version: 5.8.3
-      zod:
-        specifier: ^3.25.74
-        version: 3.25.76
 
   packages/job-store:
     dependencies:
-      '@hono/zod-openapi':
-        specifier: ^1.0.2
-        version: 1.1.0(hono@4.9.4)(zod@3.25.76)
-      '@hono/zod-validator':
-        specifier: ^0.7.2
-        version: 0.7.2(hono@4.9.4)(zod@3.25.76)
+      '@hono/swagger-ui':
+        specifier: ^0.5.2
+        version: 0.5.2(hono@4.9.4)
+      '@hono/valibot-validator':
+        specifier: ^0.5.3
+        version: 0.5.3(hono@4.9.4)(valibot@1.1.0(typescript@5.9.2))
       '@sho/models':
         specifier: workspace:*
         version: link:../models
       '@sho/scripts':
         specifier: workspace:*
         version: link:../scripts
+      '@valibot/to-json-schema':
+        specifier: ^1.3.0
+        version: 1.3.0(valibot@1.1.0(typescript@5.9.2))
       chanfana:
         specifier: ^2.8.1
         version: 2.8.2
@@ -145,16 +154,13 @@ importers:
         version: 4.9.4
       hono-openapi:
         specifier: ^0.4.8
-        version: 0.4.8(@hono/zod-validator@0.7.2(hono@4.9.4)(zod@3.25.76))(effect@3.17.9)(hono@4.9.4)(openapi-types@12.1.3)(valibot@1.1.0(typescript@5.9.2))(zod@3.25.76)
+        version: 0.4.8(@hono/valibot-validator@0.5.3(hono@4.9.4)(valibot@1.1.0(typescript@5.9.2)))(@valibot/to-json-schema@1.3.0(valibot@1.1.0(typescript@5.9.2)))(effect@3.17.9)(hono@4.9.4)(openapi-types@12.1.3)(valibot@1.1.0(typescript@5.9.2))(zod@3.25.76)
       neverthrow:
         specifier: ^8.2.0
         version: 8.2.0
       valibot:
         specifier: ^1.1.0
         version: 1.1.0(typescript@5.9.2)
-      zod:
-        specifier: ~3.25.74
-        version: 3.25.76
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.8.19
@@ -186,15 +192,15 @@ importers:
 
   packages/models:
     dependencies:
-      '@asteasolutions/zod-to-openapi':
-        specifier: ^7.2.0
-        version: 7.3.4(zod@3.25.76)
       drizzle-orm:
         specifier: ^0.44.2
         version: 0.44.5
+      valibot:
+        specifier: ^1.1.0
+        version: 1.1.0(typescript@5.9.2)
       zod:
-        specifier: ^3.25.74
-        version: 3.25.76
+        specifier: ^4.1.5
+        version: 4.1.5
     devDependencies:
       playwright:
         specifier: ^1.53.1
@@ -241,11 +247,6 @@ packages:
     resolution: {integrity: sha512-/2rThQ5zPi9OzVwes6U7lK1+Yvug0iXu25olp7S0XsYmOqnyMfxH7gdSQjn/+DSOHRg7wnotwGJSyL+fBKdnEA==}
     peerDependencies:
       zod: ^3.20.2
-
-  '@asteasolutions/zod-to-openapi@8.1.0':
-    resolution: {integrity: sha512-tQFxVs05J/6QXXqIzj6rTRk3nj1HFs4pe+uThwE95jL5II2JfpVXkK+CqkO7aT0Do5AYqO6LDrKpleLUFXgY+g==}
-    peerDependencies:
-      zod: ^4.0.0
 
   '@aws-cdk/asset-awscli-v1@2.2.242':
     resolution: {integrity: sha512-4c1bAy2ISzcdKXYS1k4HYZsNrgiwbiDzj36ybwFVxEWZXVAP0dimQTCaB9fxu7sWzEjw3d+eaw6Fon+QTfTIpQ==}
@@ -1179,18 +1180,11 @@ packages:
     peerDependencies:
       hono: '*'
 
-  '@hono/zod-openapi@1.1.0':
-    resolution: {integrity: sha512-S4jVR+A/jI4MA/RKJqmpjdHAN2l/EsqLnKHBv68x3WxV1NGVe3Sh7f6LV6rHEGYNHfiqpD75664A/erc+r9dQA==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      hono: '>=4.3.6'
-      zod: ^4.0.0
-
-  '@hono/zod-validator@0.7.2':
-    resolution: {integrity: sha512-ub5eL/NeZ4eLZawu78JpW/J+dugDAYhwqUIdp9KYScI6PZECij4Hx4UsrthlEUutqDDhPwRI0MscUfNkvn/mqQ==}
+  '@hono/valibot-validator@0.5.3':
+    resolution: {integrity: sha512-91wjmjDvrTdEm2ZcuCyLBghtld78QoLEduzfkqLo1L74n6sqqoVfc0gDfmju1Ar6w1eK8Q0UyIubrtj4KMWVnQ==}
     peerDependencies:
       hono: '>=3.9.0'
-      zod: ^3.25.0 || ^4.0.0
+      valibot: ^1.0.0 || ^1.0.0-beta.4 || ^1.0.0-rc
 
   '@img/sharp-darwin-arm64@0.33.5':
     resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
@@ -1935,6 +1929,11 @@ packages:
 
   '@types/yargs@17.0.33':
     resolution: {integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==}
+
+  '@valibot/to-json-schema@1.3.0':
+    resolution: {integrity: sha512-82Vv6x7sOYhv5YmTRgSppSqj1nn2pMCk5BqCMGWYp0V/fq+qirrbGncqZAtZ09/lrO40ne/7z8ejwE728aVreg==}
+    peerDependencies:
+      valibot: ^1.1.0
 
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
@@ -3669,6 +3668,9 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.1.5:
+    resolution: {integrity: sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==}
+
 snapshots:
 
   '@apidevtools/json-schema-ref-parser@11.9.3':
@@ -3678,11 +3680,6 @@ snapshots:
       js-yaml: 4.1.0
 
   '@asteasolutions/zod-to-openapi@7.3.4(zod@3.25.76)':
-    dependencies:
-      openapi3-ts: 4.5.0
-      zod: 3.25.76
-
-  '@asteasolutions/zod-to-openapi@8.1.0(zod@3.25.76)':
     dependencies:
       openapi3-ts: 4.5.0
       zod: 3.25.76
@@ -4578,18 +4575,10 @@ snapshots:
     dependencies:
       hono: 4.9.4
 
-  '@hono/zod-openapi@1.1.0(hono@4.9.4)(zod@3.25.76)':
-    dependencies:
-      '@asteasolutions/zod-to-openapi': 8.1.0(zod@3.25.76)
-      '@hono/zod-validator': 0.7.2(hono@4.9.4)(zod@3.25.76)
-      hono: 4.9.4
-      openapi3-ts: 4.5.0
-      zod: 3.25.76
-
-  '@hono/zod-validator@0.7.2(hono@4.9.4)(zod@3.25.76)':
+  '@hono/valibot-validator@0.5.3(hono@4.9.4)(valibot@1.1.0(typescript@5.9.2))':
     dependencies:
       hono: 4.9.4
-      zod: 3.25.76
+      valibot: 1.1.0(typescript@5.9.2)
 
   '@img/sharp-darwin-arm64@0.33.5':
     optionalDependencies:
@@ -5360,6 +5349,10 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
+  '@valibot/to-json-schema@1.3.0(valibot@1.1.0(typescript@5.9.2))':
+    dependencies:
+      valibot: 1.1.0(typescript@5.9.2)
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.2
@@ -5985,12 +5978,13 @@ snapshots:
       function-bind: 1.1.2
     optional: true
 
-  hono-openapi@0.4.8(@hono/zod-validator@0.7.2(hono@4.9.4)(zod@3.25.76))(effect@3.17.9)(hono@4.9.4)(openapi-types@12.1.3)(valibot@1.1.0(typescript@5.9.2))(zod@3.25.76):
+  hono-openapi@0.4.8(@hono/valibot-validator@0.5.3(hono@4.9.4)(valibot@1.1.0(typescript@5.9.2)))(@valibot/to-json-schema@1.3.0(valibot@1.1.0(typescript@5.9.2)))(effect@3.17.9)(hono@4.9.4)(openapi-types@12.1.3)(valibot@1.1.0(typescript@5.9.2))(zod@3.25.76):
     dependencies:
       json-schema-walker: 2.0.0
       openapi-types: 12.1.3
     optionalDependencies:
-      '@hono/zod-validator': 0.7.2(hono@4.9.4)(zod@3.25.76)
+      '@hono/valibot-validator': 0.5.3(hono@4.9.4)(valibot@1.1.0(typescript@5.9.2))
+      '@valibot/to-json-schema': 1.3.0(valibot@1.1.0(typescript@5.9.2))
       effect: 3.17.9
       hono: 4.9.4
       valibot: 1.1.0(typescript@5.9.2)
@@ -6829,6 +6823,10 @@ snapshots:
 
   v8-compile-cache-lib@3.0.1: {}
 
+  valibot@1.1.0(typescript@5.8.3):
+    optionalDependencies:
+      typescript: 5.8.3
+
   valibot@1.1.0(typescript@5.9.2):
     optionalDependencies:
       typescript: 5.9.2
@@ -7030,3 +7028,5 @@ snapshots:
   zod@3.22.3: {}
 
   zod@3.25.76: {}
+
+  zod@4.1.5: {}


### PR DESCRIPTION
…ono-openapi

主要パッケージでzod→valibot移行を実施。開発体験とテスタビリティを大幅改善。

- 移行理由
  - OpenAPIとの型整合性問題の解決
  - zodの読解困難なランタイムエラーからの脱却
  - chanfanaでのモックテスト困難さの解消
  - 関数型設計とclass-based chanfanaのインピーダンスミスマッチ解消
  - DI（依存性注入）の実現とテスト書きやすさの向上
  - scrapedJobSchemaのzod/valibot重複問題の部分的解消

- 主要な変更内容
  - packages/job-store/: zod完全削除、valibot+hono-openapi移行
  - packages/models/: 主要スキーマをvalibot化、zod v4.1.5併存（段階的移行）
  - packages/headless-crawler/: 一部valibot対応
  - apps/hello-work-job-searcher/: フロントエンド部分的valibot対応
  - packages/job-store/src/endpoint/jobList/error.ts: 削除（統合により不要）
  - 関連パッケージにtype-checkスクリプト追加
  - pnpm-lock.yaml: 依存関係更新

- 技術的改善効果
  - OpenAPIスキーマとTypeScript型の整合性向上
  - 明確で理解しやすいバリデーションエラーメッセージ
  - 関数型設計との親和性向上
  - モックテスト・単体テストの実装容易性向上
  - 依存性注入によるテスタビリティ向上
  - 部分的なバンドルサイズ削減とパフォーマンス向上

- 現在の状況
  - zodとvalibotが混在する段階的移行状態
  - job-store周りは完全にvalibot化
  - 他パッケージは部分的移行
  - 今後の完全移行に向けた基盤構築完了