### PR TITLE
fix(hello-work-software-jobs): vscodeとワークスペースのtypescriptバージョン不整合を修正

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.tsdk": "node_modules/typescript/lib"
+}


### PR DESCRIPTION
- VSCodeがプロジェクトローカルのTypeScriptライブラリを使用するよう設定
- VSCodeのグローバルTypeScriptとワークスペースのTypeScriptバージョンの不整合によるエラーを解決
- モノレポ環境でのTypeScript IntelliSenseとエラー表示を統一
- 開発者間でのTypeScript関連エラーの一貫性を確保