### PR TITLE
feat(job-store): apiエンドポイントの追加とOpenAPI仕様の改善

### DIFF
--- a/PORTFOLIO_DETAIL.md
+++ b/PORTFOLIO_DETAIL.md
@@ -511,7 +511,7 @@ const result = safeTry(async function* () {
   - ルートパスから自動的にドキュメントページへリダイレクト
   - 主要エンドポイント:
     - `POST /api/v1/job` - 求人情報登録
-    - `GET /api/v1/job/:jobNumber` - 求人詳細取得
+    - `GET /api/v1/jobs/:jobNumber` - 求人詳細取得
     - `GET /api/v1/jobs` - 求人一覧取得（高度なフィルタリング対応）
     - `GET /api/v1/jobs/continue` - 継続ページネーション（JWTトークンベース）
 

--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ graph TD
   - OpenAPI仕様書自動生成 (`/api/v1/docs`, `/docs`, `/openapi`)
   - ルートパスから自動的にドキュメントページへリダイレクト
   - 主要エンドポイント:
-    - `POST /api/v1/jobs` - 求人情報登録
-    - `GET /api/v1/job/:jobNumber` - 求人詳細取得
+    - `POST /api/v1/job` - 求人情報登録
+    - `GET /api/v1/jobs/:jobNumber` - 求人詳細取得
     - `GET /api/v1/jobs` - 求人一覧取得（高度なフィルタリング対応）
       - `companyName` - 会社名フィルタ（URLエンコード対応）
       - `jobDescription` - 職務内容キーワード検索


### PR DESCRIPTION
- GET /jobs/:jobNumber エンドポイントを新規追加（求人詳細取得機能）
- POST /jobs → /job にエンドポイントを変更（単数形に統一）
- OpenAPI仕様書のタイトルを "Hono API" → "Job Store API" に変更
- OpenAPI仕様書の説明を "Greeting API" → "Job Store API" に変更
- バージョンを "1.0.0" → "1.2" に更新
- serversフィールドを削除（不要な設定の除去）
- jobFetchParamSchemaとjobFetchRouteのimportを追加
- 404エラーハンドリング（Job not found）を実装
- README.mdとPORTFOLIO_DETAIL.mdのAPI仕様書記載を更新