### PR TITLE
fix(job-store): apiルーティング登録順序を修正し404エラーを解決

### DIFF
--- a/packages/job-store/src/app.ts
+++ b/packages/job-store/src/app.ts
@@ -44,8 +44,7 @@ export type Env = {
 export type AppContext = Context<{ Bindings: Env }>;
 
 const app = new Hono();
-const v1Api = new Hono().basePath("/api/v1"); // シンプルなログミドルウェア
-app.route("/api/v1", v1Api);
+const v1Api = new Hono(); // シンプルなログミドルウェア
 app.use("*", async (c, next) => {
   const start = Date.now();
 
@@ -318,6 +317,8 @@ v1Api.post(
     );
   },
 );
+
+app.route("/api/v1", v1Api);
 
 app.get(
   "/openapi",


### PR DESCRIPTION
- v1Apiルート定義をエンドポイント定義後に移動し、ルーティングが正常に登録されるよう修正
- basePathを削除してシンプルなルーティング構成に変更
- OpenAPIスペックからローカルサーバー設定を削除し、環境非依存に変更
- 404エラーの原因となっていたルート登録タイミングの問題を解決