### PR TITLE
fix(hello-work-job-searcher): APIエンドポイントパス修正とcommitlint設定更新

### DIFF
--- a/apps/hello-work-job-searcher/src/app/jobs/[jobNumber]/page.tsx
+++ b/apps/hello-work-job-searcher/src/app/jobs/[jobNumber]/page.tsx
@@ -14,7 +14,7 @@ export default async function Page({ params }: PageProps) {
   if (!endpoint) {
     throw new Error("JOB_STORE_ENDPOINT is not defined");
   }
-  const data = await fetch(`${endpoint}/job/${jobNumber}`).then((res) =>
+  const data = await fetch(`${endpoint}/jobs/${jobNumber}`).then((res) =>
     res.json(),
   );
   const validatedData = v.parse(jobFetchSuccessResponseSchema, data);

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,4 @@
-export default { extends: ["@commitlint/config-conventional"] };
+export default {
+  extends: ["@commitlint/config-conventional"],
+  rules: { "subject-case": [0, "always", 0] },
+};


### PR DESCRIPTION
- 求人詳細取得APIのエンドポイントパスを/job/から/jobs/に修正
- commitlint設定でsubject-caseルールを無効化（日本語コミット対応）

変更内容:
- apps/hello-work-job-searcher/src/app/jobs/[jobNumber]/page.tsx
  - fetch URLを`${endpoint}/job/${jobNumber}`から`${endpoint}/jobs/${jobNumber}`に変更
  - job-store APIの実際のルーティング(/jobs/:jobNumber)に合わせて統一
  - フロントエンドとバックエンドのAPI仕様の不整合を解消
- commitlint.config.js
  - subject-caseルールを無効化（"subject-case": [0, "always", 0]）
  - 日本語でのコミットメッセージ作成を可能にする設定追加
  - conventional commitsの他のルールは維持

技術的詳細:
- job-store APIは`v1Api.get("/jobs/:jobNumber", ...)`で定義されている
- 404エラーの原因となっていたエンドポイント不一致を修正
- RESTful設計の一貫性を保持（求人一覧: /jobs、求人詳細: /jobs/:jobNumber）