### PR TITLE
fix(job-store): Swagger UIのルーティング修正とAPIバージョンアップデート

### DIFF
--- a/packages/job-store/src/app.ts
+++ b/packages/job-store/src/app.ts
@@ -317,21 +317,21 @@ v1Api.post(
     );
   },
 );
-
 app.route("/api/v1", v1Api);
-
 app.get(
   "/openapi",
-  openAPISpecs(v1Api, {
+  openAPISpecs(app, {
     documentation: {
       info: {
         title: "Job Store API",
-        version: "1.2",
+        version: "1.3",
         description: "Job Store API",
       },
     },
   }),
 );
 app.get("/", swaggerUI({ url: "/openapi" }));
+v1Api.get("/", swaggerUI({ url: "/openapi" }));
 app.get("/docs", swaggerUI({ url: "/openapi" }));
+
 export { app };


### PR DESCRIPTION
- openAPISpecsの対象をv1Apiからappに変更してOpenAPI仕様を正しく生成
- v1Api配下にもSwagger UIエンドポイント（/）を追加
- APIバージョンを1.2から1.3にアップデート
- 不要な空行を削除してコードを整理