### PR TITLE
fix(job-store): ソート順に対応したページネーション処理を修正

### DIFF
--- a/packages/job-store/src/app.ts
+++ b/packages/job-store/src/app.ts
@@ -68,6 +68,7 @@ v1Api.get(
       jobDescription: encodedJobDescription,
       jobDescriptionExclude: encodedJobDescriptionExclude,
       onlyNotExpired,
+      orderByReceiveDate,
     } = c.req.valid("query");
     const companyName = encodedCompanyName
       ? decodeURIComponent(encodedCompanyName)
@@ -107,6 +108,7 @@ v1Api.get(
           jobDescription,
           jobDescriptionExclude,
           onlyNotExpired,
+          orderByReceiveDate,
         },
       });
 

--- a/packages/models/src/schemas/job-store/jobList/index.ts
+++ b/packages/models/src/schemas/job-store/jobList/index.ts
@@ -1,4 +1,13 @@
-import { array, boolean, number, object, optional, string } from "valibot";
+import {
+  array,
+  boolean,
+  literal,
+  number,
+  object,
+  optional,
+  string,
+  union,
+} from "valibot";
 import { jobSelectSchema } from "../drizzle";
 
 export const searchFilterSchema = object({
@@ -8,6 +17,7 @@ export const searchFilterSchema = object({
   jobDescription: optional(string()),
   jobDescriptionExclude: optional(string()), // 除外キーワード
   onlyNotExpired: optional(boolean()),
+  orderByReceiveDate: optional(union([literal("asc"), literal("desc")])),
 });
 
 export const jobListQuerySchema = searchFilterSchema;


### PR DESCRIPTION
- orderByReceiveDate パラメータに応じたカーソル条件分岐を実装
- 昇順時は gt（より大きい）、降順時は lt（より小さい）でページネーション
- カーソル取得ロジックもソート順に応じて適切な要素を選択するよう修正
- スキーマにorderByReceiveDateフィールドを追加（'asc' | 'desc'）

TODO: ロジックが複雑化したためテストケースの追加が必要