### PR TITLE
fix(job-store): ページネーションの循環バグを修正

### DIFF
--- a/packages/job-store/src/clientImpl/index.ts
+++ b/packages/job-store/src/clientImpl/index.ts
@@ -2,6 +2,7 @@ import type {
   CheckJobExistsCommand,
   CommandOutput,
   CountJobsCommand,
+  Cursor,
   FindJobByNumberCommand,
   FindJobsCommand,
   InsertJobCommand,
@@ -64,7 +65,7 @@ export const createJobStoreResultBuilder: JobStoreResultBuilder = (
   },
 
   fetchJobList: (params: {
-    cursor?: { jobId: number };
+    cursor?: Cursor;
     limit: number;
     filter: SearchFilter;
   }) => {
@@ -76,7 +77,7 @@ export const createJobStoreResultBuilder: JobStoreResultBuilder = (
       createFetchJobListError(`fetch job list failed.\n${String(error)}`),
     );
   },
-  countJobs: (params: { cursor?: { jobId: number }; filter: SearchFilter }) => {
+  countJobs: (params: { cursor?: Cursor; filter: SearchFilter }) => {
     const command: CountJobsCommand = {
       type: "CountJobs",
       options: params,

--- a/packages/job-store/src/clientImpl/type.ts
+++ b/packages/job-store/src/clientImpl/type.ts
@@ -2,6 +2,7 @@ import type {
   CheckJobExistsCommand,
   CommandOutput,
   CountJobsCommand,
+  Cursor,
   FindJobByNumberCommand,
   FindJobsCommand,
   InsertJobCommand,
@@ -39,12 +40,12 @@ export type JobStoreResultBuilder = (client: JobStoreDBClient) => {
     InsertJobDuplicationError
   >;
   fetchJobList: (params: {
-    cursor?: { jobId: number };
+    cursor?: Cursor;
     limit: number;
     filter: SearchFilter;
   }) => ResultAsync<CommandOutput<FindJobsCommand>, FetchJobListError>;
   countJobs: (params: {
-    cursor?: { jobId: number };
+    cursor?: Cursor;
     filter: SearchFilter;
   }) => ResultAsync<CommandOutput<CountJobsCommand>, FetchJobCountError>;
 };

--- a/packages/models/src/schemas/job-store/jobList/continue/index.ts
+++ b/packages/models/src/schemas/job-store/jobList/continue/index.ts
@@ -5,11 +5,14 @@ export const jobListContinueQuerySchema = object({
   nextToken: string(),
 });
 
+export const cursorSchema = object({
+  jobId: number(),
+  receivedDateByISOString: string(),
+});
+
 export const decodedNextTokenSchema = object({
   exp: number(),
-  cursor: object({
-    jobId: number(),
-  }),
+  cursor: cursorSchema,
   filter: jobListSearchFilterSchema,
 });
 

--- a/packages/models/src/types/job-store/client.ts
+++ b/packages/models/src/types/job-store/client.ts
@@ -1,8 +1,9 @@
 import type { InferOutput } from "valibot";
-import type { searchFilterSchema } from "../../schemas";
+import type { cursorSchema, searchFilterSchema } from "../../schemas";
 import type { Job } from "./jobFetch";
 import type { InsertJobRequestBody } from "./jobInsert";
 
+export type Cursor = InferOutput<typeof cursorSchema>;
 // --- コマンド型 ---
 export type InsertJobCommand = {
   type: "InsertJob";
@@ -15,7 +16,7 @@ export type FindJobByNumberCommand = {
 export type FindJobsCommand = {
   type: "FindJobs";
   options: {
-    cursor?: { jobId: number };
+    cursor?: Cursor;
     limit: number;
     filter: SearchFilter;
   };
@@ -28,7 +29,7 @@ export type CheckJobExistsCommand = {
 export type CountJobsCommand = {
   type: "CountJobs";
   options: {
-    cursor?: { jobId: number };
+    cursor?: Cursor;
     filter: SearchFilter;
   };
 };
@@ -47,7 +48,7 @@ export interface CommandOutputMap {
   FindJobByNumber: { job: Job | null };
   FindJobs: {
     jobs: Job[];
-    cursor: { jobId: number };
+    cursor: Cursor;
     meta: { totalCount: number; filter: SearchFilter };
   };
   CheckJobExists: { exists: boolean };


### PR DESCRIPTION
- Cursorに`receivedDateByISOString`フィールドを追加してカーソル位置を正確に特定
- 複合カーソル（jobId + receivedDate）による重複データ取得を防止
- 同一受信日時の求人でもIDによる正確な順序付けを実現
- JWTトークンのペイロードにreceivedDateByISOStringを含めるよう修正
- Drizzle ORMクエリでのOR条件による複合カーソル処理を実装
- 無限ループしていたページネーションを修正