### PR TITLE
fix(models): transform employee count from string to number in job li…

### DIFF
--- a/packages/models/src/schemas/job-store/jobList/index.ts
+++ b/packages/models/src/schemas/job-store/jobList/index.ts
@@ -5,15 +5,27 @@ import {
   number,
   object,
   optional,
+  pipe,
   string,
+  transform,
   union,
 } from "valibot";
 import { jobSelectSchema } from "../drizzle";
 
 export const searchFilterSchema = object({
   companyName: optional(string()),
-  employeeCountLt: optional(number()),
-  employeeCountGt: optional(number()),
+  employeeCountLt: optional(
+    pipe(
+      string(),
+      transform((input) => (input === undefined ? undefined : Number(input))),
+    ),
+  ),
+  employeeCountGt: optional(
+    pipe(
+      string(),
+      transform((input) => (input === undefined ? undefined : Number(input))),
+    ),
+  ),
   jobDescription: optional(string()),
   jobDescriptionExclude: optional(string()), // 除外キーワード
   onlyNotExpired: optional(boolean()),


### PR DESCRIPTION
…st schema

- employeeCountLt と employeeCountGt のスキーマを number() から pipe(string(), transform()) に変更
- フロントエンドからのクエリパラメータ（文字列）を数値に自動変換する機能を追加
- valibot の transform と pipe を新たにインポート
- API エンドポイントでの型安全性を向上させ、文字列パラメータの数値変換を自動化