### PR TITLE
fix(job-store): improve JWT payload validation error message formatting

### DIFF
--- a/packages/job-store/src/app.ts
+++ b/packages/job-store/src/app.ts
@@ -196,7 +196,7 @@ v1Api.get(
       if (!payloadValidation.success) {
         return err(
           createDecodeJWTPayloadError(
-            `Decoding JWT payload failed.\n${String(payloadValidation.issues)}`,
+            `Decoding JWT payload failed.\n${String(payloadValidation.issues.map((i) => i.message).join("\n"))}`,
           ),
         );
       }


### PR DESCRIPTION
- JWTペイロードのバリデーションエラーが[object Object]として表示される問題を修正
- issuesオブジェクトの配列から個別のメッセージを抽出して改行区切りで表示
- デバッグ時のエラー内容の可読性を大幅に向上