### PR TITLE
fix(job-store): employeeCountGt/Lt パラメータのランタイムエラーを修正

### DIFF
--- a/packages/job-store/src/endpoint/error.ts
+++ b/packages/job-store/src/endpoint/error.ts
@@ -20,6 +20,29 @@ export type EnvError = {
   readonly message: string;
 };
 
+export type EmployeeCountGtValidationError = {
+  readonly _tag: "EmployeeCountGtValidationError";
+  readonly message: string;
+};
+export type EmployeeCountLtValidationError = {
+  readonly _tag: "EmployeeCountLtValidationError";
+  readonly message: string;
+};
+
+export const createEmployeeCountGtValidationError = (
+  message: string,
+): EmployeeCountGtValidationError => ({
+  _tag: "EmployeeCountGtValidationError",
+  message,
+});
+
+export const createEmployeeCountLtValidationError = (
+  message: string,
+): EmployeeCountLtValidationError => ({
+  _tag: "EmployeeCountLtValidationError",
+  message,
+});
+
 export const createJWTSignatureError = (
   message: string,
 ): JWTSignatureError => ({

--- a/packages/models/src/schemas/job-store/jobList/index.ts
+++ b/packages/models/src/schemas/job-store/jobList/index.ts
@@ -5,9 +5,7 @@ import {
   number,
   object,
   optional,
-  pipe,
   string,
-  transform,
   union,
 } from "valibot";
 import { jobSelectSchema } from "../drizzle";
@@ -24,18 +22,8 @@ export const searchFilterSchema = object({
 
 export const jobListQuerySchema = object({
   ...searchFilterSchema.entries,
-  employeeCount: optional(
-    pipe(
-      string(),
-      transform((input) => (input === undefined ? undefined : Number(input))),
-    ),
-  ),
-  employeeCountGt: optional(
-    pipe(
-      string(),
-      transform((input) => (input === undefined ? undefined : Number(input))),
-    ),
-  ),
+  employeeCount: optional(string()),
+  employeeCountGt: optional(string()),
 });
 
 export const jobListSearchFilterSchema = searchFilterSchema;


### PR DESCRIPTION
- transformによるランタイムで追えないエラーの問題を解決
- employeeCountGt/Ltパラメータの型変換処理をクエリスキーマから実装ロジックに分離
- 明示的なsafeParse戦略に変更してエラーハンドリングを改善
- 新しいバリデーションエラータイプ（EmployeeCountGtValidationError, EmployeeCountLtValidationError）を定義
- 400 Bad Requestステータスでクライアントエラーを返すように修正
- ランタイムエラーの追跡可能性を向上