### PR TITLE
fix(job-store): 従業員数フィルタのバリデーションを整数のみに制限

### DIFF
--- a/packages/job-store/src/app.ts
+++ b/packages/job-store/src/app.ts
@@ -95,7 +95,10 @@ v1Api.get(
 
     const result = safeTry(async function* () {
       const employeeCountGt = yield* (() => {
-        const result = safeParse(v.number(), rawEmployeeCountGt);
+        const result = safeParse(
+          v.pipe(v.number(), v.integer()),
+          Number(rawEmployeeCountGt),
+        );
         if (!result.success)
           return err(
             createEmployeeCountGtValidationError("Invalid employeeCountGt"),
@@ -103,7 +106,10 @@ v1Api.get(
         return ok(result.output);
       })();
       const employeeCountLt = yield* (() => {
-        const result = safeParse(v.number(), rawEmployeeCountLt);
+        const result = safeParse(
+          v.pipe(v.number(), v.integer()),
+          Number(rawEmployeeCountLt),
+        );
         if (!result.success)
           return err(
             createEmployeeCountLtValidationError("Invalid employeeCountLt"),

--- a/packages/models/src/schemas/job-store/jobList/index.ts
+++ b/packages/models/src/schemas/job-store/jobList/index.ts
@@ -1,10 +1,12 @@
 import {
   array,
   boolean,
+  integer,
   literal,
   number,
   object,
   optional,
+  pipe,
   string,
   union,
 } from "valibot";
@@ -12,8 +14,8 @@ import { jobSelectSchema } from "../drizzle";
 
 export const searchFilterSchema = object({
   companyName: optional(string()),
-  employeeCountLt: optional(number()),
-  employeeCountGt: optional(number()),
+  employeeCountLt: optional(pipe(number(), integer())),
+  employeeCountGt: optional(pipe(number(), integer())),
   jobDescription: optional(string()),
   jobDescriptionExclude: optional(string()), // 除外キーワード
   onlyNotExpired: optional(boolean()),


### PR DESCRIPTION
- employeeCountGt/employeeCountLtパラメータで整数のみを受け付けるように修正
- valibotのpipe(number(), integer())を使用してバリデーション強化
- APIエンドポイントとスキーマ定義の両方で一貫性を保持
- 不正な小数値入力によるエラーを防止