### PR TITLE
fix(job-store): employeeCountパラメータのバリデーションエラーメッセージを詳細化

### DIFF
--- a/packages/job-store/src/app.ts
+++ b/packages/job-store/src/app.ts
@@ -101,7 +101,9 @@ v1Api.get(
         );
         if (!result.success)
           return err(
-            createEmployeeCountGtValidationError("Invalid employeeCountGt"),
+            createEmployeeCountGtValidationError(
+              `Invalid employeeCountGt.${result.issues.map((issue) => issue.message).join("\n")}`,
+            ),
           );
         return ok(result.output);
       })();
@@ -112,7 +114,9 @@ v1Api.get(
         );
         if (!result.success)
           return err(
-            createEmployeeCountLtValidationError("Invalid employeeCountLt"),
+            createEmployeeCountLtValidationError(
+              `Invalid employeeCountLt.${result.issues.map((issue) => issue.message).join("\n")}`,
+            ),
           );
         return ok(result.output);
       })();


### PR DESCRIPTION
- employeeCountGt/employeeCountLtのバリデーションエラーメッセージを改善
- valibotのissue情報を含めることで、具体的なスキーマエラー内容を表示
- 「スキーマエラーが出てるけど、エラーがどうなってるか分からない」問題を解決