### PR TITLE
fix(job-store): employeeCount パラメータの undefined バリデーション処理を追加

### DIFF
--- a/packages/job-store/src/app.ts
+++ b/packages/job-store/src/app.ts
@@ -95,6 +95,7 @@ v1Api.get(
 
     const result = safeTry(async function* () {
       const employeeCountGt = yield* (() => {
+        if (rawEmployeeCountGt === undefined) return ok(undefined);
         const result = safeParse(
           v.pipe(v.number(), v.integer()),
           Number(rawEmployeeCountGt),
@@ -108,6 +109,7 @@ v1Api.get(
         return ok(result.output);
       })();
       const employeeCountLt = yield* (() => {
+        if (rawEmployeeCountLt === undefined) return ok(undefined);
         const result = safeParse(
           v.pipe(v.number(), v.integer()),
           Number(rawEmployeeCountLt),


### PR DESCRIPTION
- employeeCountGt が undefined の場合の早期リターン処理を追加
- employeeCountLt が undefined の場合の早期リターン処理を追加
- Number() 変換前に undefined チェックを行うことで、不正な値の処理を防止
- API の安定性とエラーハンドリングを改善