### PR TITLE
fix(job-store): HTTPエラーレスポンスのハンドリング改善とスキーマ修正

### DIFF
--- a/apps/hello-work-job-searcher/src/app/store/server/index.ts
+++ b/apps/hello-work-job-searcher/src/app/store/server/index.ts
@@ -59,6 +59,14 @@ export const jobStoreClientOnServer: JobStoreClient = {
         createParseJsonError(`Failed to parse jobs response: ${String(error)}`),
       );
 
+      if (!response.ok) {
+        return err(
+          createFetchJobsError(
+            `Failed to fetch jobs.\nstatus: ${response.status}\nbody: ${JSON.stringify(data, null, 2)}`,
+          ),
+        );
+      }
+
       const validatedData = yield* (() => {
         const result = v.safeParse(jobListSuccessResponseSchema, data);
         if (!result.success) {
@@ -94,6 +102,14 @@ export const jobStoreClientOnServer: JobStoreClient = {
       const data = yield* ResultAsync.fromPromise(response.json(), (error) =>
         createParseJsonError(`Failed to parse jobs response: ${String(error)}`),
       );
+
+      if (!response.ok) {
+        return err(
+          createFetchJobsError(
+            `Failed to fetch jobs.\nstatus: ${response.status}\nbody: ${JSON.stringify(data, null, 2)}`,
+          ),
+        );
+      }
 
       const validatedData = yield* (() => {
         const result = v.safeParse(jobListSuccessResponseSchema, data);

--- a/packages/models/src/schemas/job-store/jobList/index.ts
+++ b/packages/models/src/schemas/job-store/jobList/index.ts
@@ -3,7 +3,7 @@ import { JobListSchema, searchFilterSchema } from "../client";
 
 export const jobListQuerySchema = object({
   ...searchFilterSchema.entries,
-  employeeCount: optional(string()),
+  employeeCountLt: optional(string()),
   employeeCountGt: optional(string()),
 });
 


### PR DESCRIPTION
- job-store APIクライアントでHTTPエラーレスポンス（4xx/5xx）の適切なハンドリングを追加
- getInitialJobs()とgetContinuedJobs()でresponse.okチェックを実装
- エラー時にステータスコードとレスポンスボディを含む詳細なエラーメッセージを提供
- jobListQuerySchemaのemployeeCountフィールドをemployeeCountLtに修正（従業員数上限フィルタとして正しく機能）
- バリデーション前のHTTPエラーチェックにより、不正なレスポンスでのバリデーションエラーを防止