### PR TITLE
feat(hello-work-job-searcher): Next.js APIテスト基盤の構築とサーバーサイドバリデーション強化

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,6 @@
 pnpm --filter job-store run copy-schema
 pnpm --filter job-store run test run
+pnpm --filter hello-work-job-searcher run test
 git add packages/job-store/src/db/schema.ts
 pnpm exec lint-staged
 pnpm type-check

--- a/apps/hello-work-job-searcher/.gitignore
+++ b/apps/hello-work-job-searcher/.gitignore
@@ -42,3 +42,10 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Playwright
+node_modules/
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/apps/hello-work-job-searcher/package.json
+++ b/apps/hello-work-job-searcher/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test": "pnpm exec playwright test"
   },
   "dependencies": {
     "@sho/models": "workspace:*",
@@ -20,6 +21,7 @@
     "valibot": "^1.1.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.55.0",
     "@types/node": "^22.0.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/apps/hello-work-job-searcher/playwright.config.ts
+++ b/apps/hello-work-job-searcher/playwright.config.ts
@@ -1,0 +1,79 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// import dotenv from 'dotenv';
+// import path from 'path';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: "./tests",
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: "html",
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: "http://localhost:9002",
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: "on-first-retry",
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+
+    // {
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'] },
+    // },
+
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    // },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: "pnpm dev",
+    url: "http://localhost:9002",
+    reuseExistingServer: true,
+  },
+});

--- a/apps/hello-work-job-searcher/src/app/api/proxy/job-store/jobs/route.ts
+++ b/apps/hello-work-job-searcher/src/app/api/proxy/job-store/jobs/route.ts
@@ -10,25 +10,14 @@ export async function GET(request: NextRequest) {
   const jobDescriptionExclude =
     searchParams.get("jobDescriptionExclude") ?? undefined;
 
-  const employeeCountGt =
-    employeeCountGtRaw !== null && employeeCountGtRaw !== ""
-      ? Number(employeeCountGtRaw)
-      : undefined;
-  const employeeCountLt =
-    employeeCountLtRaw !== null && employeeCountLtRaw !== ""
-      ? Number(employeeCountLtRaw)
-      : undefined;
-
   const filter: Record<string, unknown> = {};
   if (companyName) filter.companyName = companyName;
-  if (typeof employeeCountGt === "number" && !Number.isNaN(employeeCountGt))
-    filter.employeeCountGt = employeeCountGt;
-  if (typeof employeeCountLt === "number" && !Number.isNaN(employeeCountLt))
-    filter.employeeCountLt = employeeCountLt;
   if (jobDescription) filter.jobDescription = jobDescription;
   if (jobDescriptionExclude)
     filter.jobDescriptionExclude = jobDescriptionExclude;
 
+  filter.employeeCountGt = employeeCountGtRaw ?? undefined;
+  filter.employeeCountLt = employeeCountLtRaw ?? undefined;
   filter.orderByReceiveDate = "desc";
 
   const result = await jobStoreClientOnServer.getInitialJobs(filter);

--- a/apps/hello-work-job-searcher/tests/index.spec.ts
+++ b/apps/hello-work-job-searcher/tests/index.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "@playwright/test";
+
+// /api/proxy/job-store/jobs GET: クエリ異常系
+
+test.describe("/api/proxy/job-store/jobs", () => {
+  test("should return 500 for invalid employeeCountGt (not a number)", async ({
+    request,
+  }) => {
+    const res = await request.get(
+      "/api/proxy/job-store/jobs?employeeCountGt=abc",
+    );
+    expect(res.status()).toBe(500);
+    const json = await res.json();
+    expect(json).toHaveProperty("error");
+  });
+});

--- a/packages/job-store/src/app.ts
+++ b/packages/job-store/src/app.ts
@@ -97,7 +97,7 @@ v1Api.get(
       const employeeCountGt = yield* (() => {
         if (rawEmployeeCountGt === undefined) return ok(undefined);
         const result = safeParse(
-          v.pipe(v.number(), v.integer()),
+          v.pipe(v.number(), v.integer(), v.minValue(0)),
           Number(rawEmployeeCountGt),
         );
         if (!result.success)

--- a/packages/job-store/test/tsconfig.json
+++ b/packages/job-store/test/tsconfig.json
@@ -1,5 +1,5 @@
 {
 	"extends": "../tsconfig.json",
-	"include": ["./**/*.ts"],
+	"include": ["./**/*.ts","../worker-configuration.d.ts"],
 	"exclude": []
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ importers:
         version: 8.2.0
       next:
         specifier: 15.5.2
-        version: 15.5.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 15.5.2(@playwright/test@1.55.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       react:
         specifier: 19.1.1
         version: 19.1.1
@@ -58,6 +58,9 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0(typescript@5.8.3)
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.55.0
+        version: 1.55.0
       '@types/node':
         specifier: ^22.0.0
         version: 22.18.0
@@ -1319,6 +1322,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.55.0':
+    resolution: {integrity: sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@poppinss/colors@4.1.5':
     resolution: {integrity: sha512-FvdDqtcRCtz6hThExcFOgW0cWX+xwSMWcRuQe5ZEb2m7cVQOAVZOIMt+/v9RxGiD9/OY16qJBXK4CVKWAPalBw==}
@@ -4342,6 +4350,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.55.0':
+    dependencies:
+      playwright: 1.55.0
+
   '@poppinss/colors@4.1.5':
     dependencies:
       kleur: 4.1.5
@@ -5593,7 +5605,7 @@ snapshots:
     optionalDependencies:
       '@rollup/rollup-linux-x64-gnu': 4.50.0
 
-  next@15.5.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+  next@15.5.2(@playwright/test@1.55.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
       '@next/env': 15.5.2
       '@swc/helpers': 0.5.15
@@ -5611,6 +5623,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.5.2
       '@next/swc-win32-arm64-msvc': 15.5.2
       '@next/swc-win32-x64-msvc': 15.5.2
+      '@playwright/test': 1.55.0
       sharp: 0.34.3
     transitivePeerDependencies:
       - '@babel/core'


### PR DESCRIPTION
- Playwright設定ファイル（playwright.config.ts）を追加してNext.js APIテスト基盤を構築
- APIエンドポイント異常系テスト（tests/index.spec.ts）を追加
- package.jsonにPlaywright依存関係とテストスクリプトを追加
- .gitignoreにPlaywright関連ファイルを追加
- pre-commitフックにhello-work-job-searcherのテスト実行を追加
- API proxy routeでemployeeCount系パラメータ処理をサーバーサイドに移譲
- job-store server側でクエリパラメータのバリデーション強化（jobListQuerySchemaを使用）
- job-store app.tsでemployeeCountGtに最小値0の制約を追加

テスト環境設定:
- baseURL: http://localhost:9002
- Chromiumブラウザでのテスト実行
- CI環境での並列実行制御
- HTML形式のレポート出力

今後のテストカバレッジ拡張に向けた基盤を整備