### PR TITLE
ci(hello-work-software-jobs): actions/setup-node@v5のバグ回避のためv4にダウングレード

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
 


### PR DESCRIPTION
- actions/setup-node@v5で報告されているバグ（GitHub Issue #1357）を回避
- actions/setup-node@v4に一時的にダウングレードして安定性を確保
- CI/CDパイプラインの信頼性向上
- バグ修正版がリリースされるまでの暫定対応
- https://github.com/actions/setup-node/issues/1357