### PR TITLE
ci(hello-work-software-jobs): actions/setup-nodeとpnpmの互換性問題を修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,13 +14,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: 'pnpm'
       - uses: pnpm/action-setup@v4
         with:
           version: 10.15.1
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+
+
+      - name: Check pnpm version
+        run: pnpm --version
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
- pnpm/action-setupをactions/setup-nodeより先に実行するよう順序を変更
- actions/setup-nodeをv4からv5にアップデート
- pnpmバージョン確認ステップを追加
- Node.jsセットアップからcacheオプションを削除
- GitHub actions/setup-node#530の問題に対応