### PR TITLE
fix(hello-work-software-jobs): GitHub ActionsデプロイワークフローにAPI_KEY環境変数を追…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,5 +45,6 @@ jobs:
           JOB_STORE_ENDPOINT: ${{ secrets.JOB_STORE_ENDPOINT }}
           MAIL_ADDRESS: ${{ secrets.MAIL_ADDRESS }}
           QUEUE_URL: ${{ secrets.QUEUE_URL }}
+          API_KEY: ${{ secrets.API_KEY }}
         run: |
           pnpm exec cdk deploy --all --require-approval never


### PR DESCRIPTION
…加して401エラーを修正

- クラウド環境でのAPI認証エラー（401 Unauthorized）を解決
- デプロイ時にAPI_KEYシークレットを環境変数として設定
- job-store APIへのアクセス時の認証に必要な設定を追加
- CDKデプロイプロセスでの認証機能を正常化