### PR TITLE
fix(job-store): ルーティング順序の修正とwranglerアップデート

### DIFF
--- a/packages/job-store/package.json
+++ b/packages/job-store/package.json
@@ -21,7 +21,7 @@
 		"tsx": "^4.20.3",
 		"typescript": "^5.5.2",
 		"vitest": "~3.2.4",
-		"wrangler": "^4.26.1"
+		"wrangler": "4.34.0"
 	},
 	"dependencies": {
 		"@hono/swagger-ui": "^0.5.2",

--- a/packages/job-store/src/app.ts
+++ b/packages/job-store/src/app.ts
@@ -26,9 +26,10 @@ app.use("*", async (c, next) => {
   const duration = Date.now() - start;
   console.log(`📤 ${c.res.status} (${duration}ms)`);
 });
+// こっちを先にしないと、/apiv/v1/jobs/:jobNumberに飛んでしまう
+app.route("/api/v1/jobs/continue", jobsContinue);
 app.route("/api/v1/job", job);
 app.route("/api/v1/jobs", jobs);
-app.route("/api/v1/jobs/continue", jobsContinue);
 app.get(
   "/openapi",
   openAPISpecs(app, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,7 +184,7 @@ importers:
         specifier: ~3.2.4
         version: 3.2.4(@types/node@24.3.1)(jiti@2.5.1)(tsx@4.20.5)(yaml@2.8.1)
       wrangler:
-        specifier: ^4.26.1
+        specifier: 4.34.0
         version: 4.34.0
 
   packages/models:


### PR DESCRIPTION
- /api/v1/jobs/continue ルートを /api/v1/jobs より先に配置
- ルーティングの競合を防ぐため、より具体的なパスを優先
- wrangler を 4.26.1 から 4.34.0 にアップデート
- API エンドポイントのルーティング順序を最適化

注意: 現在のルーティング設計は複雑になっているため、
将来的には /jobs/continue を廃止し、/jobs のクエリパラメータ
nextToken として統合することを検討中（破壊的変更のため後回し）