### PR TITLE
ci(hello-work-software-jobs): CI/CDセキュリティの段階的改善

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,12 +13,12 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
         with:
           version: 10.15.1
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22
 
@@ -33,7 +33,7 @@ jobs:
           pnpm -r --filter='!hello-work-job-searcher' --filter='!job-store' build
       # 👇 OIDCによるAssumeRole
       - name: Configure AWS CDK Credentials via OIDC
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 # v5.0.0
         with:
           role-to-assume: ${{ secrets.CDK_DEPLOY_ROLE_ARN }}
           role-session-name: github-actions-oidc

--- a/.github/workflows/run-lambda-weekly-days.yml
+++ b/.github/workflows/run-lambda-weekly-days.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 # v5.0.0
         with:
           role-to-assume: ${{ secrets.HELLO_WORK_CRAWLER_INVOCATION_ROLE_ARN }}
           aws-region: ap-northeast-1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,3 +4,6 @@ pnpm --filter hello-work-job-searcher run test
 git add packages/job-store/src/db/schema.ts
 pnpm exec lint-staged
 pnpm type-check
+nix-shell -p pinact run 
+git add .github/workflows/* 
+

--- a/renovate.json
+++ b/renovate.json
@@ -13,5 +13,13 @@
     "prBodyDefinitions": {
       "Change": "All locks refreshed"
     }
-  }
+  },
+  "packageRules": [
+    {
+      "matchDatasources": [
+        "npm"
+      ],
+      "minimalReleaseAge": "7 days"
+    }
+  ]
 }


### PR DESCRIPTION
サプライチェーン攻撃対策の一環として、CI/CDパイプラインのセキュリティを段階的に強化。
まだ完全ではないが、重要な改善を実施。

実施内容:
- GitHub Actionsの部分的Pin化（コミットハッシュ固定）
  - actions/checkout@v5 → @08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
  - pnpm/action-setup@v4 → @a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
  - actions/setup-node@v5 → @a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
  - aws-actions/configure-aws-credentials@v5 → @a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 # v5.0.0
- pre-commitフックにpinactツールを統合
  - 自動Pin化プロセスの導入（`nix-shell -p pinact run`）
  - ワークフローファイルの自動ステージング
- Renovate設定の最適化

対象ファイル:
- .github/workflows/deploy.yml
- .github/workflows/run-lambda-weekly-days.yml
- .husky/pre-commit
- renovate.json

現状の課題認識:
- 全てのGitHub ActionsのPin化が未完了
- その他のセキュリティベストプラクティスも段階的に適用予定
- 継続的なセキュリティ改善が必要

参考資料:
- https://zenn.dev/azu/articles/ad168118524135
- https://gihyo.jp/article/2025/09/npm-supply-chain-attack

今後の改善予定:
- 残りのGitHub ActionsのPin化
- 権限の最小化（permissions設定の見直し）
- シークレット管理の強化
- 依存関係スキャンの導入