### PR TITLE
feat(headless-crawler): デッドレターキュー監視機能を追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,5 +46,6 @@ jobs:
           MAIL_ADDRESS: ${{ secrets.MAIL_ADDRESS }}
           QUEUE_URL: ${{ secrets.QUEUE_URL }}
           API_KEY: ${{ secrets.API_KEY }}
+          GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN }}
         run: |
           pnpm exec cdk deploy --all --require-approval never

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -18,9 +18,9 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.head_ref }}
-          fetch-depth: 0  # main も fetch して差分取得可能にする
+          fetch-depth: 0
 
-      # 2. Disable husky (for CI)
+      # 2. Disable husky (for CI, kill hooks)
       - name: Disable husky
         run: git config core.hooksPath /dev/null
 
@@ -49,22 +49,16 @@ jobs:
         run: pnpm -r exec tsc --noEmit
         continue-on-error: false
 
-      # 8. Format & Lint changed files (JS/TS/JSX/TSX だけ)
+      # 8. Format & Lint changed files
       - name: Format & Lint changed files
         run: |
-          # 改行を安全に扱うために配列で取得
           mapfile -t CHANGED_FILES < <(git diff --name-only origin/main...HEAD | grep -E '\.(js|ts|jsx|tsx)$')
 
           if [ ${#CHANGED_FILES[@]} -gt 0 ]; then
             echo "Changed files: ${CHANGED_FILES[@]}"
 
-            # フォーマット
             pnpm exec biome format --write "${CHANGED_FILES[@]}"
-
-            # Lint + safe fix
             pnpm exec biome lint --write --no-errors-on-unmatched "${CHANGED_FILES[@]}"
-
-            # ステージ
             git add "${CHANGED_FILES[@]}"
           else
             echo "No JS/TS/JSX/TSX files changed"
@@ -84,6 +78,9 @@ jobs:
       - name: Commit formatting & lint fixes
         if: steps.format-check.outputs.formatted == 'true'
         run: |
+          # 念押しで husky 無効化（ここ大事）
+          git config core.hooksPath /dev/null
+
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git commit -m "style: auto-format and lint fixes [skip ci]"
@@ -97,3 +94,12 @@ jobs:
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '🎨 Code has been automatically formatted and linted.'
+            })
+
+      # 12. Run tests
+      - name: Run tests
+        run: pnpm run test
+        continue-on-error: false

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -12,10 +12,6 @@ jobs:
       pull-requests: write
 
     steps:
-      # 0. Disable husky (for CI)
-      - name: Disable husky
-        run: git config core.hooksPath /dev/null
-
       # 1. Checkout code
       - name: Checkout code
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
@@ -24,32 +20,36 @@ jobs:
           ref: ${{ github.head_ref }}
           fetch-depth: 0  # main も fetch して差分取得可能にする
 
-      # 2. Setup Node.js
+      # 2. Disable husky (for CI)
+      - name: Disable husky
+        run: git config core.hooksPath /dev/null
+
+      # 3. Setup Node.js
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
 
-      # 3. Install pnpm
+      # 4. Install pnpm
       - name: Install pnpm
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
         with:
           version: 10.15.1
 
-      # 4. Install dependencies
+      # 5. Install dependencies
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # 5. Build
+      # 6. Build
       - name: Build packages
         run: pnpm -r build
 
-      # 6. Type check
+      # 7. Type check
       - name: Type check
         run: pnpm -r exec tsc --noEmit
         continue-on-error: false
 
-      # 7. Format & Lint changed files (JS/TS/JSX/TSX だけ)
+      # 8. Format & Lint changed files (JS/TS/JSX/TSX だけ)
       - name: Format & Lint changed files
         run: |
           # 改行を安全に扱うために配列で取得
@@ -70,7 +70,7 @@ jobs:
             echo "No JS/TS/JSX/TSX files changed"
           fi
 
-      # 8. Check if formatting or linting changed files
+      # 9. Check if formatting or linting changed files
       - name: Check if formatting or linting changed files
         id: format-check
         run: |
@@ -80,7 +80,7 @@ jobs:
             echo "formatted=true" >> $GITHUB_OUTPUT
           fi
 
-      # 9. Commit formatting & lint fixes
+      # 10. Commit formatting & lint fixes
       - name: Commit formatting & lint fixes
         if: steps.format-check.outputs.formatted == 'true'
         run: |
@@ -89,7 +89,7 @@ jobs:
           git commit -m "style: auto-format and lint fixes [skip ci]"
           git push
 
-      # 10. Comment on PR if formatted
+      # 11. Comment on PR if formatted
       - name: Comment on PR if formatted
         if: steps.format-check.outputs.formatted == 'true'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
@@ -97,12 +97,3 @@ jobs:
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '🎨 Code has been automatically formatted and linted.'
-            })
-
-      # 11. Run tests
-      - name: Run tests
-        run: pnpm run test
-        continue-on-error: false

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -12,6 +12,10 @@ jobs:
       pull-requests: write
 
     steps:
+      # 0. Disable husky (for CI)
+      - name: Disable husky
+        run: git config core.hooksPath /dev/null
+
       # 1. Checkout code
       - name: Checkout code
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0

--- a/packages/headless-crawler/README.md
+++ b/packages/headless-crawler/README.md
@@ -1,13 +1,93 @@
-# Welcome to your CDK TypeScript project
+# Headless Crawler
 
-This is a blank project for CDK development with TypeScript.
+ハローワークの求人情報を自動収集するためのヘッドレスクローラーシステムです。
 
-The `cdk.json` file tells the CDK Toolkit how to execute your app.
+## アーキテクチャ
 
-## Useful commands
+このシステムは以下のAWSサービスを使用しています：
 
-- `npm run build` compile typescript to js
-- `npm run watch` watch for changes and compile
-- `npx cdk deploy` deploy this stack to your default AWS account/region
-- `npx cdk diff` compare deployed stack with current state
-- `npx cdk synth` emits the synthesized CloudFormation template
+- **AWS Lambda**: クローリング・スクレイピング処理
+- **Amazon SQS**: ジョブキューとデッドレターキュー
+- **Amazon EventBridge**: 定期実行スケジュール
+- **Amazon SNS**: アラート通知
+- **Amazon CloudWatch**: メトリクス監視
+
+## 主要機能
+
+### 1. 求人情報クローリング
+- 定期的にハローワークサイトから求人情報を収集
+- EventBridgeによる自動スケジュール実行（毎週月曜日午前1時）
+
+### 2. スクレイピング処理
+- SQSキューからジョブを受信して個別の求人詳細を取得
+- 失敗時の自動リトライ機能（最大3回）
+
+### 3. デッドレターキュー監視
+- 処理に失敗したメッセージを自動監視
+- 平日毎日午前9時にチェック実行
+- エラー発生時にGitHub Issueを自動作成
+- 詳細なエラー情報とトラブルシューティング項目を含む
+
+## 環境変数
+
+以下の環境変数が必要です：
+
+```bash
+# 必須
+JOB_STORE_ENDPOINT=<求人データ保存先API>
+API_KEY=<API認証キー>
+QUEUE_URL=<SQSキューURL>
+MAIL_ADDRESS=<アラート通知先メールアドレス>
+
+# GitHub連携（オプション）
+GITHUB_TOKEN=<GitHubアクセストークン>
+```
+
+## デプロイ
+
+```bash
+# 依存関係のインストール
+pnpm install
+
+# CDKデプロイ
+pnpm exec cdk deploy --all --require-approval never
+```
+
+## 開発用コマンド
+
+```bash
+# TypeScript型チェック
+pnpm run type-check
+
+# クローラーの動作確認
+pnpm run verify:crawler
+
+# スクレイパーの動作確認
+pnpm run verify:scraper
+```
+
+## 監視とアラート
+
+### CloudWatchアラーム
+- Lambda実行回数が1000回/時間を超えた場合にSNS通知
+
+### デッドレターキュー監視
+- 処理失敗メッセージの自動検出
+- GitHub Issue自動作成による問題追跡
+- 詳細なエラー情報とスタックトレースの記録
+
+## トラブルシューティング
+
+### よくある問題
+
+1. **Lambda実行エラー**
+   - CloudWatchログを確認
+   - メモリ不足の場合はメモリサイズを調整
+
+2. **デッドレターキューにメッセージが蓄積**
+   - GitHub Issueで詳細なエラー情報を確認
+   - 根本原因を修正後、必要に応じてメッセージを再処理
+
+3. **GitHub Issue作成エラー**
+   - GITHUB_TOKEN環境変数の設定を確認
+   - トークンの権限（Issues作成権限）を確認

--- a/packages/headless-crawler/lib/functions/deadLetterMonitor/handler.ts
+++ b/packages/headless-crawler/lib/functions/deadLetterMonitor/handler.ts
@@ -1,107 +1,127 @@
-import { SQSClient, GetQueueAttributesCommand, ReceiveMessageCommand } from "@aws-sdk/client-sqs";
+import {
+  SQSClient,
+  GetQueueAttributesCommand,
+  ReceiveMessageCommand,
+} from "@aws-sdk/client-sqs";
 import { Octokit } from "octokit";
 import type { ScheduledEvent } from "aws-lambda";
 
-const sqsClient = new SQSClient({ region: process.env.AWS_REGION || "us-east-1" });
+const sqsClient = new SQSClient({
+  region: process.env.AWS_REGION || "us-east-1",
+});
 
 export const handler = async (_event: ScheduledEvent) => {
-    console.log("デッドレターキューの監視を開始しました");
+  console.log("デッドレターキューの監視を開始しました");
 
-    const queueUrl = process.env.DEAD_LETTER_QUEUE_URL;
-    const githubToken = process.env.GITHUB_TOKEN;
-    const githubOwner = process.env.GITHUB_OWNER;
-    const githubRepo = process.env.GITHUB_REPO;
+  const queueUrl = process.env.DEAD_LETTER_QUEUE_URL;
+  const githubToken = process.env.GITHUB_TOKEN;
+  const githubOwner = process.env.GITHUB_OWNER;
+  const githubRepo = process.env.GITHUB_REPO;
 
-    if (!queueUrl) {
-        console.error("DEAD_LETTER_QUEUE_URL環境変数が設定されていません");
-        return;
-    }
+  if (!queueUrl) {
+    console.error("DEAD_LETTER_QUEUE_URL環境変数が設定されていません");
+    return;
+  }
 
-    try {
-        // SQSキューの属性を取得（メッセージ数をチェック）
-        const command = new GetQueueAttributesCommand({
-            QueueUrl: queueUrl,
-            AttributeNames: ["ApproximateNumberOfMessages"],
+  try {
+    // SQSキューの属性を取得（メッセージ数をチェック）
+    const command = new GetQueueAttributesCommand({
+      QueueUrl: queueUrl,
+      AttributeNames: ["ApproximateNumberOfMessages"],
+    });
+
+    const response = await sqsClient.send(command);
+    const messageCount = Number.parseInt(
+      response.Attributes?.ApproximateNumberOfMessages || "0",
+    );
+
+    console.log(`デッドレターキューのメッセージ数: ${messageCount}`);
+
+    if (messageCount > 0) {
+      console.log(
+        `⚠️  デッドレターキューに${messageCount}件のメッセージが見つかりました`,
+      );
+
+      // デッドレターキューからメッセージの詳細を取得
+      try {
+        const receiveCommand = new ReceiveMessageCommand({
+          QueueUrl: queueUrl,
+          MaxNumberOfMessages: 10, // 最大10件取得
+          VisibilityTimeout: 30, // 30秒間他の処理から見えなくする
+          WaitTimeSeconds: 1, // ロングポーリング（1秒）
+          MessageAttributeNames: ["All"], // すべての属性を取得
         });
 
-        const response = await sqsClient.send(command);
-        const messageCount = Number.parseInt(response.Attributes?.ApproximateNumberOfMessages || "0");
+        const messages = await sqsClient.send(receiveCommand);
 
-        console.log(`デッドレターキューのメッセージ数: ${messageCount}`);
+        if (messages.Messages && messages.Messages.length > 0) {
+          console.log(
+            `📨 ${messages.Messages.length}件のメッセージを取得しました:`,
+          );
 
-        if (messageCount > 0) {
-            console.log(`⚠️  デッドレターキューに${messageCount}件のメッセージが見つかりました`);
+          const errorDetails: string[] = [];
 
-            // デッドレターキューからメッセージの詳細を取得
+          messages.Messages.forEach((message, index) => {
+            console.log(`\n--- メッセージ ${index + 1} ---`);
+            console.log("メッセージID:", message.MessageId);
+            console.log("メッセージ本文:", message.Body);
+
+            // エラー詳細を収集
+            let errorSummary = `### エラー ${index + 1}\n`;
+            errorSummary += `**メッセージID**: ${message.MessageId}\n`;
+
+            // システム属性
+            if (message.Attributes) {
+              console.log(
+                "  - 受信回数:",
+                message.Attributes.ApproximateReceiveCount,
+              );
+              console.log(
+                "  - 送信時刻:",
+                new Date(
+                  Number.parseInt(message.Attributes.SentTimestamp || "0"),
+                ).toISOString(),
+              );
+              errorSummary += `**リトライ回数**: ${message.Attributes.ApproximateReceiveCount}\n`;
+              errorSummary += `**送信時刻**: ${new Date(Number.parseInt(message.Attributes.SentTimestamp || "0")).toISOString()}\n`;
+            }
+
+            // メッセージ本文をJSONとしてパース
             try {
-                const receiveCommand = new ReceiveMessageCommand({
-                    QueueUrl: queueUrl,
-                    MaxNumberOfMessages: 10, // 最大10件取得
-                    VisibilityTimeout: 30,   // 30秒間他の処理から見えなくする
-                    WaitTimeSeconds: 1,      // ロングポーリング（1秒）
-                    MessageAttributeNames: ["All"], // すべての属性を取得
-                });
+              const parsedBody = JSON.parse(message.Body || "");
+              if (parsedBody.errorMessage) {
+                console.log("🚨 エラー:", parsedBody.errorMessage);
+                errorSummary += `**エラー**: ${parsedBody.errorMessage}\n`;
+              }
+              if (parsedBody.errorType) {
+                console.log("🚨 タイプ:", parsedBody.errorType);
+                errorSummary += `**タイプ**: ${parsedBody.errorType}\n`;
+              }
+              errorSummary += `\n\`\`\`json\n${JSON.stringify(parsedBody, null, 2)}\n\`\`\`\n`;
+            } catch (e) {
+              console.error("メッセージ本文のパースエラー:", e);
+              // JSON形式でない場合はそのまま表示
+              errorSummary += `\n\`\`\`\n${message.Body}\n\`\`\`\n`;
+            }
 
-                const messages = await sqsClient.send(receiveCommand);
+            errorDetails.push(errorSummary);
+          });
 
-                if (messages.Messages && messages.Messages.length > 0) {
-                    console.log(`📨 ${messages.Messages.length}件のメッセージを取得しました:`);
+          // GitHub Issue作成
+          if (githubToken && githubOwner && githubRepo) {
+            try {
+              const octokit = new Octokit({ auth: githubToken });
 
-                    const errorDetails: string[] = [];
-
-                    messages.Messages.forEach((message, index) => {
-                        console.log(`\n--- メッセージ ${index + 1} ---`);
-                        console.log("メッセージID:", message.MessageId);
-                        console.log("メッセージ本文:", message.Body);
-
-                        // エラー詳細を収集
-                        let errorSummary = `### エラー ${index + 1}\n`;
-                        errorSummary += `**メッセージID**: ${message.MessageId}\n`;
-
-                        // システム属性
-                        if (message.Attributes) {
-                            console.log("  - 受信回数:", message.Attributes.ApproximateReceiveCount);
-                            console.log("  - 送信時刻:", new Date(Number.parseInt(message.Attributes.SentTimestamp || "0")).toISOString());
-                            errorSummary += `**リトライ回数**: ${message.Attributes.ApproximateReceiveCount}\n`;
-                            errorSummary += `**送信時刻**: ${new Date(Number.parseInt(message.Attributes.SentTimestamp || "0")).toISOString()}\n`;
-                        }
-
-                        // メッセージ本文をJSONとしてパース
-                        try {
-                            const parsedBody = JSON.parse(message.Body || "");
-                            if (parsedBody.errorMessage) {
-                                console.log("🚨 エラー:", parsedBody.errorMessage);
-                                errorSummary += `**エラー**: ${parsedBody.errorMessage}\n`;
-                            }
-                            if (parsedBody.errorType) {
-                                console.log("🚨 タイプ:", parsedBody.errorType);
-                                errorSummary += `**タイプ**: ${parsedBody.errorType}\n`;
-                            }
-                            errorSummary += `\n\`\`\`json\n${JSON.stringify(parsedBody, null, 2)}\n\`\`\`\n`;
-                        } catch (e) {
-                            console.error("メッセージ本文のパースエラー:", e);
-                            // JSON形式でない場合はそのまま表示
-                            errorSummary += `\n\`\`\`\n${message.Body}\n\`\`\`\n`;
-                        }
-
-                        errorDetails.push(errorSummary);
-                    });
-
-                    // GitHub Issue作成
-                    if (githubToken && githubOwner && githubRepo) {
-                        try {
-                            const octokit = new Octokit({ auth: githubToken });
-
-                            const title = `デッドレターキューエラー - ${new Date().toISOString().split('T')[0]} (${messages.Messages.length}件)`;
-                            const body = `
+              const title = `デッドレターキューエラー - ${new Date().toISOString().split("T")[0]} (${messages.Messages.length}件)`;
+              const body = `
 ## デッドレターキューエラーレポート
 
-**日時**: ${new Date().toLocaleString('ja-JP')}  
+**日時**: ${new Date().toLocaleString("ja-JP")}  
 **総メッセージ数**: ${messages.Messages.length}件
 
 ## エラー詳細
 
-${errorDetails.join('\n')}
+${errorDetails.join("\n")}
 
 ## 対応項目
 - [ ] エラーの根本原因を調査する
@@ -113,36 +133,39 @@ ${errorDetails.join('\n')}
 *デッドレターキューモニターによる自動生成*
               `.trim();
 
-                            const issue = await octokit.rest.issues.create({
-                                owner: githubOwner,
-                                repo: githubRepo,
-                                title,
-                                body,
-                                labels: ['bug', 'dead-letter-queue', 'monitoring']
-                            });
+              const issue = await octokit.rest.issues.create({
+                owner: githubOwner,
+                repo: githubRepo,
+                title,
+                body,
+                labels: ["bug", "dead-letter-queue", "monitoring"],
+              });
 
-                            console.log(`✅ GitHub Issueを作成しました: ${issue.data.html_url}`);
-                        } catch (error) {
-                            console.error("❌ GitHub Issue作成エラー:", error);
-                        }
-                    } else {
-                        console.log("⚠️  GitHub連携が設定されていません（トークン/オーナー/リポジトリが不足）");
-                    }
-                }
+              console.log(
+                `✅ GitHub Issueを作成しました: ${issue.data.html_url}`,
+              );
             } catch (error) {
-                console.error("メッセージ取得エラー:", error);
+              console.error("❌ GitHub Issue作成エラー:", error);
             }
-
-        } else {
-            console.log("✅ デッドレターキューにメッセージはありません");
+          } else {
+            console.log(
+              "⚠️  GitHub連携が設定されていません（トークン/オーナー/リポジトリが不足）",
+            );
+          }
         }
-
-        return {
-            statusCode: 200,
-            messageCount,
-        };
-    } catch (error) {
-        console.error("デッドレターキュー監視エラー:", error);
-        throw error;
+      } catch (error) {
+        console.error("メッセージ取得エラー:", error);
+      }
+    } else {
+      console.log("✅ デッドレターキューにメッセージはありません");
     }
+
+    return {
+      statusCode: 200,
+      messageCount,
+    };
+  } catch (error) {
+    console.error("デッドレターキュー監視エラー:", error);
+    throw error;
+  }
 };

--- a/packages/headless-crawler/lib/functions/deadLetterMonitor/handler.ts
+++ b/packages/headless-crawler/lib/functions/deadLetterMonitor/handler.ts
@@ -1,0 +1,148 @@
+import { SQSClient, GetQueueAttributesCommand, ReceiveMessageCommand } from "@aws-sdk/client-sqs";
+import { Octokit } from "octokit";
+import type { ScheduledEvent } from "aws-lambda";
+
+const sqsClient = new SQSClient({ region: process.env.AWS_REGION || "us-east-1" });
+
+export const handler = async (_event: ScheduledEvent) => {
+    console.log("デッドレターキューの監視を開始しました");
+
+    const queueUrl = process.env.DEAD_LETTER_QUEUE_URL;
+    const githubToken = process.env.GITHUB_TOKEN;
+    const githubOwner = process.env.GITHUB_OWNER;
+    const githubRepo = process.env.GITHUB_REPO;
+
+    if (!queueUrl) {
+        console.error("DEAD_LETTER_QUEUE_URL環境変数が設定されていません");
+        return;
+    }
+
+    try {
+        // SQSキューの属性を取得（メッセージ数をチェック）
+        const command = new GetQueueAttributesCommand({
+            QueueUrl: queueUrl,
+            AttributeNames: ["ApproximateNumberOfMessages"],
+        });
+
+        const response = await sqsClient.send(command);
+        const messageCount = Number.parseInt(response.Attributes?.ApproximateNumberOfMessages || "0");
+
+        console.log(`デッドレターキューのメッセージ数: ${messageCount}`);
+
+        if (messageCount > 0) {
+            console.log(`⚠️  デッドレターキューに${messageCount}件のメッセージが見つかりました`);
+
+            // デッドレターキューからメッセージの詳細を取得
+            try {
+                const receiveCommand = new ReceiveMessageCommand({
+                    QueueUrl: queueUrl,
+                    MaxNumberOfMessages: 10, // 最大10件取得
+                    VisibilityTimeout: 30,   // 30秒間他の処理から見えなくする
+                    WaitTimeSeconds: 1,      // ロングポーリング（1秒）
+                    MessageAttributeNames: ["All"], // すべての属性を取得
+                });
+
+                const messages = await sqsClient.send(receiveCommand);
+
+                if (messages.Messages && messages.Messages.length > 0) {
+                    console.log(`📨 ${messages.Messages.length}件のメッセージを取得しました:`);
+
+                    const errorDetails: string[] = [];
+
+                    messages.Messages.forEach((message, index) => {
+                        console.log(`\n--- メッセージ ${index + 1} ---`);
+                        console.log("メッセージID:", message.MessageId);
+                        console.log("メッセージ本文:", message.Body);
+
+                        // エラー詳細を収集
+                        let errorSummary = `### エラー ${index + 1}\n`;
+                        errorSummary += `**メッセージID**: ${message.MessageId}\n`;
+
+                        // システム属性
+                        if (message.Attributes) {
+                            console.log("  - 受信回数:", message.Attributes.ApproximateReceiveCount);
+                            console.log("  - 送信時刻:", new Date(Number.parseInt(message.Attributes.SentTimestamp || "0")).toISOString());
+                            errorSummary += `**リトライ回数**: ${message.Attributes.ApproximateReceiveCount}\n`;
+                            errorSummary += `**送信時刻**: ${new Date(Number.parseInt(message.Attributes.SentTimestamp || "0")).toISOString()}\n`;
+                        }
+
+                        // メッセージ本文をJSONとしてパース
+                        try {
+                            const parsedBody = JSON.parse(message.Body || "");
+                            if (parsedBody.errorMessage) {
+                                console.log("🚨 エラー:", parsedBody.errorMessage);
+                                errorSummary += `**エラー**: ${parsedBody.errorMessage}\n`;
+                            }
+                            if (parsedBody.errorType) {
+                                console.log("🚨 タイプ:", parsedBody.errorType);
+                                errorSummary += `**タイプ**: ${parsedBody.errorType}\n`;
+                            }
+                            errorSummary += `\n\`\`\`json\n${JSON.stringify(parsedBody, null, 2)}\n\`\`\`\n`;
+                        } catch (e) {
+                            console.error("メッセージ本文のパースエラー:", e);
+                            // JSON形式でない場合はそのまま表示
+                            errorSummary += `\n\`\`\`\n${message.Body}\n\`\`\`\n`;
+                        }
+
+                        errorDetails.push(errorSummary);
+                    });
+
+                    // GitHub Issue作成
+                    if (githubToken && githubOwner && githubRepo) {
+                        try {
+                            const octokit = new Octokit({ auth: githubToken });
+
+                            const title = `デッドレターキューエラー - ${new Date().toISOString().split('T')[0]} (${messages.Messages.length}件)`;
+                            const body = `
+## デッドレターキューエラーレポート
+
+**日時**: ${new Date().toLocaleString('ja-JP')}  
+**総メッセージ数**: ${messages.Messages.length}件
+
+## エラー詳細
+
+${errorDetails.join('\n')}
+
+## 対応項目
+- [ ] エラーの根本原因を調査する
+- [ ] 根本的な問題を修正する  
+- [ ] 失敗したメッセージの再処理を検討する
+- [ ] 必要に応じてエラーハンドリングを更新する
+
+---
+*デッドレターキューモニターによる自動生成*
+              `.trim();
+
+                            const issue = await octokit.rest.issues.create({
+                                owner: githubOwner,
+                                repo: githubRepo,
+                                title,
+                                body,
+                                labels: ['bug', 'dead-letter-queue', 'monitoring']
+                            });
+
+                            console.log(`✅ GitHub Issueを作成しました: ${issue.data.html_url}`);
+                        } catch (error) {
+                            console.error("❌ GitHub Issue作成エラー:", error);
+                        }
+                    } else {
+                        console.log("⚠️  GitHub連携が設定されていません（トークン/オーナー/リポジトリが不足）");
+                    }
+                }
+            } catch (error) {
+                console.error("メッセージ取得エラー:", error);
+            }
+
+        } else {
+            console.log("✅ デッドレターキューにメッセージはありません");
+        }
+
+        return {
+            statusCode: 200,
+            messageCount,
+        };
+    } catch (error) {
+        console.error("デッドレターキュー監視エラー:", error);
+        throw error;
+    }
+};

--- a/packages/headless-crawler/lib/stack/headless-crawler-stack.ts
+++ b/packages/headless-crawler/lib/stack/headless-crawler-stack.ts
@@ -105,20 +105,24 @@ export class HeadlessCrawlerStack extends cdk.Stack {
     );
 
     // デッドレターキュー監視用Lambda（定期実行）
-    const deadLetterMonitor = new NodejsFunction(this, "DeadLetterMonitorFunction", {
-      entry: "lib/functions/deadLetterMonitor/handler.ts",
-      handler: "handler",
-      runtime: lambda.Runtime.NODEJS_22_X,
-      memorySize: 512,
-      timeout: Duration.seconds(30),
-      environment: {
-        DEAD_LETTER_QUEUE_URL: deadLetterQueue.queueUrl,
-        SNS_TOPIC_ARN: scraperAlarmTopic.topicArn,
-        GITHUB_TOKEN: process.env.GITHUB_TOKEN || "",
-        GITHUB_OWNER: "shidari",
-        GITHUB_REPO: "hello-work-software-jobs",
+    const deadLetterMonitor = new NodejsFunction(
+      this,
+      "DeadLetterMonitorFunction",
+      {
+        entry: "lib/functions/deadLetterMonitor/handler.ts",
+        handler: "handler",
+        runtime: lambda.Runtime.NODEJS_22_X,
+        memorySize: 512,
+        timeout: Duration.seconds(30),
+        environment: {
+          DEAD_LETTER_QUEUE_URL: deadLetterQueue.queueUrl,
+          SNS_TOPIC_ARN: scraperAlarmTopic.topicArn,
+          GITHUB_TOKEN: process.env.GITHUB_TOKEN || "",
+          GITHUB_OWNER: "shidari",
+          GITHUB_REPO: "hello-work-software-jobs",
+        },
       },
-    });
+    );
 
     // 定期的にデッドレターキューをチェック（平日毎日朝9時）
     const deadLetterCheckRule = new events.Rule(this, "DeadLetterCheckRule", {
@@ -129,7 +133,9 @@ export class HeadlessCrawlerStack extends cdk.Stack {
       }),
     });
 
-    deadLetterCheckRule.addTarget(new targets.LambdaFunction(deadLetterMonitor));
+    deadLetterCheckRule.addTarget(
+      new targets.LambdaFunction(deadLetterMonitor),
+    );
 
     // 必要な権限を付与
     deadLetterQueue.grantConsumeMessages(deadLetterMonitor);

--- a/packages/headless-crawler/package.json
+++ b/packages/headless-crawler/package.json
@@ -28,6 +28,7 @@
     "constructs": "^10.0.0",
     "dotenv": "^17.0.0",
     "effect": "^3.16.5",
+    "octokit": "^5.0.3",
     "playwright": "^1.53.1",
     "valibot": "^1.1.0",
     "zod": "^4.1.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
       effect:
         specifier: ^3.16.5
         version: 3.17.9
+      octokit:
+        specifier: ^5.0.3
+        version: 5.0.3
       playwright:
         specifier: ^1.53.1
         version: 1.55.0
@@ -1361,6 +1364,119 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@octokit/app@16.1.0':
+    resolution: {integrity: sha512-OdKHnm0CYLk8Setr47CATT4YnRTvWkpTYvE+B/l2B0mjszlfOIit3wqPHVslD2jfc1bD4UbO7Mzh6gjCuMZKsA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-app@8.1.0':
+    resolution: {integrity: sha512-6bWhyvLXqCSfHiqlwzn9pScLZ+Qnvh/681GR/UEEPCMIVwfpRDBw0cCzy3/t2Dq8B7W2X/8pBgmw6MOiyE0DXQ==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-oauth-app@9.0.1':
+    resolution: {integrity: sha512-TthWzYxuHKLAbmxdFZwFlmwVyvynpyPmjwc+2/cI3cvbT7mHtsAW9b1LvQaNnAuWL+pFnqtxdmrU8QpF633i1g==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-oauth-device@8.0.1':
+    resolution: {integrity: sha512-TOqId/+am5yk9zor0RGibmlqn4V0h8vzjxlw/wYr3qzkQxl8aBPur384D1EyHtqvfz0syeXji4OUvKkHvxk/Gw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-oauth-user@6.0.0':
+    resolution: {integrity: sha512-GV9IW134PHsLhtUad21WIeP9mlJ+QNpFd6V9vuPWmaiN25HEJeEQUcS4y5oRuqCm9iWDLtfIs+9K8uczBXKr6A==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-token@6.0.0':
+    resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-unauthenticated@7.0.1':
+    resolution: {integrity: sha512-qVq1vdjLLZdE8kH2vDycNNjuJRCD1q2oet1nA/GXWaYlpDxlR7rdVhX/K/oszXslXiQIiqrQf+rdhDlA99JdTQ==}
+    engines: {node: '>= 20'}
+
+  '@octokit/core@7.0.4':
+    resolution: {integrity: sha512-jOT8V1Ba5BdC79sKrRWDdMT5l1R+XNHTPR6CPWzUP2EcfAcvIHZWF0eAbmRcpOOP5gVIwnqNg0C4nvh6Abc3OA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/endpoint@11.0.0':
+    resolution: {integrity: sha512-hoYicJZaqISMAI3JfaDr1qMNi48OctWuOih1m80bkYow/ayPw6Jj52tqWJ6GEoFTk1gBqfanSoI1iY99Z5+ekQ==}
+    engines: {node: '>= 20'}
+
+  '@octokit/graphql@9.0.1':
+    resolution: {integrity: sha512-j1nQNU1ZxNFx2ZtKmL4sMrs4egy5h65OMDmSbVyuCzjOcwsHq6EaYjOTGXPQxgfiN8dJ4CriYHk6zF050WEULg==}
+    engines: {node: '>= 20'}
+
+  '@octokit/oauth-app@8.0.1':
+    resolution: {integrity: sha512-QnhMYEQpnYbEPn9cae+wXL2LuPMFglmfeuDJXXsyxIXdoORwkLK8y0cHhd/5du9MbO/zdG/BXixzB7EEwU63eQ==}
+    engines: {node: '>= 20'}
+
+  '@octokit/oauth-authorization-url@8.0.0':
+    resolution: {integrity: sha512-7QoLPRh/ssEA/HuHBHdVdSgF8xNLz/Bc5m9fZkArJE5bb6NmVkDm3anKxXPmN1zh6b5WKZPRr3697xKT/yM3qQ==}
+    engines: {node: '>= 20'}
+
+  '@octokit/oauth-methods@6.0.0':
+    resolution: {integrity: sha512-Q8nFIagNLIZgM2odAraelMcDssapc+lF+y3OlcIPxyAU+knefO8KmozGqfnma1xegRDP4z5M73ABsamn72bOcA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/openapi-types@25.1.0':
+    resolution: {integrity: sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==}
+
+  '@octokit/openapi-types@26.0.0':
+    resolution: {integrity: sha512-7AtcfKtpo77j7Ts73b4OWhOZHTKo/gGY8bB3bNBQz4H+GRSWqx2yvj8TXRsbdTE0eRmYmXOEY66jM7mJ7LzfsA==}
+
+  '@octokit/openapi-webhooks-types@12.0.3':
+    resolution: {integrity: sha512-90MF5LVHjBedwoHyJsgmaFhEN1uzXyBDRLEBe7jlTYx/fEhPAk3P3DAJsfZwC54m8hAIryosJOL+UuZHB3K3yA==}
+
+  '@octokit/plugin-paginate-graphql@6.0.0':
+    resolution: {integrity: sha512-crfpnIoFiBtRkvPqOyLOsw12XsveYuY2ieP6uYDosoUegBJpSVxGwut9sxUgFFcll3VTOTqpUf8yGd8x1OmAkQ==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-paginate-rest@13.1.1':
+    resolution: {integrity: sha512-q9iQGlZlxAVNRN2jDNskJW/Cafy7/XE52wjZ5TTvyhyOD904Cvx//DNyoO3J/MXJ0ve3rPoNWKEg5iZrisQSuw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-rest-endpoint-methods@16.1.0':
+    resolution: {integrity: sha512-nCsyiKoGRnhH5LkH8hJEZb9swpqOcsW+VXv1QoyUNQXJeVODG4+xM6UICEqyqe9XFr6LkL8BIiFCPev8zMDXPw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-retry@8.0.1':
+    resolution: {integrity: sha512-KUoYR77BjF5O3zcwDQHRRZsUvJwepobeqiSSdCJ8lWt27FZExzb0GgVxrhhfuyF6z2B2zpO0hN5pteni1sqWiw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=7'
+
+  '@octokit/plugin-throttling@11.0.1':
+    resolution: {integrity: sha512-S+EVhy52D/272L7up58dr3FNSMXWuNZolkL4zMJBNIfIxyZuUcczsQAU4b5w6dewJXnKYVgSHSV5wxitMSW1kw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': ^7.0.0
+
+  '@octokit/request-error@7.0.0':
+    resolution: {integrity: sha512-KRA7VTGdVyJlh0cP5Tf94hTiYVVqmt2f3I6mnimmaVz4UG3gQV/k4mDJlJv3X67iX6rmN7gSHCF8ssqeMnmhZg==}
+    engines: {node: '>= 20'}
+
+  '@octokit/request@10.0.3':
+    resolution: {integrity: sha512-V6jhKokg35vk098iBqp2FBKunk3kMTXlmq+PtbV9Gl3TfskWlebSofU9uunVKhUN7xl+0+i5vt0TGTG8/p/7HA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/types@14.1.0':
+    resolution: {integrity: sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==}
+
+  '@octokit/types@15.0.0':
+    resolution: {integrity: sha512-8o6yDfmoGJUIeR9OfYU0/TUJTnMPG2r68+1yEdUeG2Fdqpj8Qetg0ziKIgcBm0RW/j29H41WP37CYCEhp6GoHQ==}
+
+  '@octokit/webhooks-methods@6.0.0':
+    resolution: {integrity: sha512-MFlzzoDJVw/GcbfzVC1RLR36QqkTLUf79vLVO3D+xn7r0QgxnFoLZgtrzxiQErAjFUOdH6fas2KeQJ1yr/qaXQ==}
+    engines: {node: '>= 20'}
+
+  '@octokit/webhooks@14.1.3':
+    resolution: {integrity: sha512-gcK4FNaROM9NjA0mvyfXl0KPusk7a1BeA8ITlYEZVQCXF5gcETTd4yhAU0Kjzd8mXwYHppzJBWgdBVpIR9wUcQ==}
+    engines: {node: '>= 20'}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -1963,11 +2079,17 @@ packages:
       bare-events:
         optional: true
 
+  before-after-hook@4.0.0:
+    resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
   birpc@0.2.14:
     resolution: {integrity: sha512-37FHE8rqsYM5JEKCnXFyHpBCzvgHEExwVVTq+nUmloInU7l8ezD1TpOhKpS8oe1DTYFqEK27rFZVKG43oTqXRA==}
 
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
+  bottleneck@2.19.5:
+    resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
 
   bowser@2.12.1:
     resolution: {integrity: sha512-z4rE2Gxh7tvshQ4hluIT7XcFrgLIQaw9X3A+kTTRdovCz5PMukm/0QC/BKSYPj3omF5Qfypn9O/c5kgpmvYUCw==}
@@ -2349,6 +2471,9 @@ packages:
   fast-check@3.23.2:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
     engines: {node: '>=8.0.0'}
+
+  fast-content-type-parse@3.0.0:
+    resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -2743,6 +2868,10 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  octokit@5.0.3:
+    resolution: {integrity: sha512-+bwYsAIRmYv30NTmBysPIlgH23ekVDriB07oRxlPIAH5PI0yTMSxg5i5Xy0OetcnZw+nk/caD4szD7a9YZ3QyQ==}
+    engines: {node: '>= 20'}
+
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
@@ -3111,6 +3240,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toad-cache@3.7.0:
+    resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
+    engines: {node: '>=12'}
+
   tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
 
@@ -3190,6 +3323,12 @@ packages:
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
     engines: {node: '>=18'}
+
+  universal-github-app-jwt@2.2.2:
+    resolution: {integrity: sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw==}
+
+  universal-user-agent@7.0.3:
+    resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
 
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
@@ -4465,6 +4604,159 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.2':
     optional: true
 
+  '@octokit/app@16.1.0':
+    dependencies:
+      '@octokit/auth-app': 8.1.0
+      '@octokit/auth-unauthenticated': 7.0.1
+      '@octokit/core': 7.0.4
+      '@octokit/oauth-app': 8.0.1
+      '@octokit/plugin-paginate-rest': 13.1.1(@octokit/core@7.0.4)
+      '@octokit/types': 14.1.0
+      '@octokit/webhooks': 14.1.3
+
+  '@octokit/auth-app@8.1.0':
+    dependencies:
+      '@octokit/auth-oauth-app': 9.0.1
+      '@octokit/auth-oauth-user': 6.0.0
+      '@octokit/request': 10.0.3
+      '@octokit/request-error': 7.0.0
+      '@octokit/types': 14.1.0
+      toad-cache: 3.7.0
+      universal-github-app-jwt: 2.2.2
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-oauth-app@9.0.1':
+    dependencies:
+      '@octokit/auth-oauth-device': 8.0.1
+      '@octokit/auth-oauth-user': 6.0.0
+      '@octokit/request': 10.0.3
+      '@octokit/types': 14.1.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-oauth-device@8.0.1':
+    dependencies:
+      '@octokit/oauth-methods': 6.0.0
+      '@octokit/request': 10.0.3
+      '@octokit/types': 14.1.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-oauth-user@6.0.0':
+    dependencies:
+      '@octokit/auth-oauth-device': 8.0.1
+      '@octokit/oauth-methods': 6.0.0
+      '@octokit/request': 10.0.3
+      '@octokit/types': 14.1.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-token@6.0.0': {}
+
+  '@octokit/auth-unauthenticated@7.0.1':
+    dependencies:
+      '@octokit/request-error': 7.0.0
+      '@octokit/types': 14.1.0
+
+  '@octokit/core@7.0.4':
+    dependencies:
+      '@octokit/auth-token': 6.0.0
+      '@octokit/graphql': 9.0.1
+      '@octokit/request': 10.0.3
+      '@octokit/request-error': 7.0.0
+      '@octokit/types': 15.0.0
+      before-after-hook: 4.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/endpoint@11.0.0':
+    dependencies:
+      '@octokit/types': 14.1.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/graphql@9.0.1':
+    dependencies:
+      '@octokit/request': 10.0.3
+      '@octokit/types': 14.1.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/oauth-app@8.0.1':
+    dependencies:
+      '@octokit/auth-oauth-app': 9.0.1
+      '@octokit/auth-oauth-user': 6.0.0
+      '@octokit/auth-unauthenticated': 7.0.1
+      '@octokit/core': 7.0.4
+      '@octokit/oauth-authorization-url': 8.0.0
+      '@octokit/oauth-methods': 6.0.0
+      '@types/aws-lambda': 8.10.152
+      universal-user-agent: 7.0.3
+
+  '@octokit/oauth-authorization-url@8.0.0': {}
+
+  '@octokit/oauth-methods@6.0.0':
+    dependencies:
+      '@octokit/oauth-authorization-url': 8.0.0
+      '@octokit/request': 10.0.3
+      '@octokit/request-error': 7.0.0
+      '@octokit/types': 14.1.0
+
+  '@octokit/openapi-types@25.1.0': {}
+
+  '@octokit/openapi-types@26.0.0': {}
+
+  '@octokit/openapi-webhooks-types@12.0.3': {}
+
+  '@octokit/plugin-paginate-graphql@6.0.0(@octokit/core@7.0.4)':
+    dependencies:
+      '@octokit/core': 7.0.4
+
+  '@octokit/plugin-paginate-rest@13.1.1(@octokit/core@7.0.4)':
+    dependencies:
+      '@octokit/core': 7.0.4
+      '@octokit/types': 14.1.0
+
+  '@octokit/plugin-rest-endpoint-methods@16.1.0(@octokit/core@7.0.4)':
+    dependencies:
+      '@octokit/core': 7.0.4
+      '@octokit/types': 15.0.0
+
+  '@octokit/plugin-retry@8.0.1(@octokit/core@7.0.4)':
+    dependencies:
+      '@octokit/core': 7.0.4
+      '@octokit/request-error': 7.0.0
+      '@octokit/types': 14.1.0
+      bottleneck: 2.19.5
+
+  '@octokit/plugin-throttling@11.0.1(@octokit/core@7.0.4)':
+    dependencies:
+      '@octokit/core': 7.0.4
+      '@octokit/types': 14.1.0
+      bottleneck: 2.19.5
+
+  '@octokit/request-error@7.0.0':
+    dependencies:
+      '@octokit/types': 14.1.0
+
+  '@octokit/request@10.0.3':
+    dependencies:
+      '@octokit/endpoint': 11.0.0
+      '@octokit/request-error': 7.0.0
+      '@octokit/types': 14.1.0
+      fast-content-type-parse: 3.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/types@14.1.0':
+    dependencies:
+      '@octokit/openapi-types': 25.1.0
+
+  '@octokit/types@15.0.0':
+    dependencies:
+      '@octokit/openapi-types': 26.0.0
+
+  '@octokit/webhooks-methods@6.0.0': {}
+
+  '@octokit/webhooks@14.1.3':
+    dependencies:
+      '@octokit/openapi-webhooks-types': 12.0.3
+      '@octokit/request-error': 7.0.0
+      '@octokit/webhooks-methods': 6.0.0
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -5081,9 +5373,13 @@ snapshots:
       bare-events: 2.6.1
     optional: true
 
+  before-after-hook@4.0.0: {}
+
   birpc@0.2.14: {}
 
   blake3-wasm@2.1.5: {}
+
+  bottleneck@2.19.5: {}
 
   bowser@2.12.1: {}
 
@@ -5406,6 +5702,8 @@ snapshots:
   fast-check@3.23.2:
     dependencies:
       pure-rand: 6.1.0
+
+  fast-content-type-parse@3.0.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -5783,6 +6081,20 @@ snapshots:
       - babel-plugin-macros
 
   object-assign@4.1.1: {}
+
+  octokit@5.0.3:
+    dependencies:
+      '@octokit/app': 16.1.0
+      '@octokit/core': 7.0.4
+      '@octokit/oauth-app': 8.0.1
+      '@octokit/plugin-paginate-graphql': 6.0.0(@octokit/core@7.0.4)
+      '@octokit/plugin-paginate-rest': 13.1.1(@octokit/core@7.0.4)
+      '@octokit/plugin-rest-endpoint-methods': 16.1.0(@octokit/core@7.0.4)
+      '@octokit/plugin-retry': 8.0.1(@octokit/core@7.0.4)
+      '@octokit/plugin-throttling': 11.0.1(@octokit/core@7.0.4)
+      '@octokit/request-error': 7.0.0
+      '@octokit/types': 14.1.0
+      '@octokit/webhooks': 14.1.3
 
   ohash@2.0.11: {}
 
@@ -6175,6 +6487,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toad-cache@3.7.0: {}
+
   tr46@1.0.1:
     dependencies:
       punycode: 2.3.1
@@ -6259,6 +6573,10 @@ snapshots:
       ufo: 1.6.1
 
   unicorn-magic@0.1.0: {}
+
+  universal-github-app-jwt@2.2.2: {}
+
+  universal-user-agent@7.0.3: {}
 
   universalify@2.0.1: {}
 


### PR DESCRIPTION
- SQSデッドレターキューの自動監視機能を実装
- 平日毎日午前9時に定期チェックを実行
- エラー発生時にGitHub Issue自動作成機能を追加
- デッドレターキューからのメッセージ詳細取得とエラー分析
- GitHub Actions デプロイワークフローにGITHUB_TOKEN環境変数を追加
- octokitライブラリを依存関係に追加
- READMEにデッドレターキュー監視機能の説明を追加
- 詳細なエラー情報とトラブルシューティング項目を含むIssue作成

注意: 監視処理はvibe codingで実装（末端処理のため必要に応じて書き捨て可能）