### PR TITLE
fix(headless-crawler): GitHub Actionsワークフローのworking-directoryパスを修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
           aws-region: ap-northeast-1
 
       - name: Deploy AWS CDK
-        working-directory: ./packages/headless-crawler
+        working-directory: ./apps/headless-crawler
         env:
           JOB_STORE_ENDPOINT: ${{ secrets.JOB_STORE_ENDPOINT }}
           MAIL_ADDRESS: ${{ secrets.MAIL_ADDRESS }}


### PR DESCRIPTION
## 背景

プロジェクトの構造変更により、`headless-crawler`が`packages/`ディレクトリから`apps/`ディレクトリに移動されました。しかし、GitHub ActionsのDeployワークフロー（`.github/workflows/deploy.yml`）では、まだ古いパス`./packages/headless-crawler`が使用されており、デプロイが失敗する状態になっています。

## このプルリクで何を解決するか

- GitHub ActionsのDeployワークフローで使用されている`working-directory`を`./packages/headless-crawler`から`./apps/headless-crawler`に修正
- CDKデプロイコマンドが正しいディレクトリで実行されるようにし、デプロイの失敗を解決
- PR Checksワークフローとの一貫性を保持（PR Checksでは既に正しいパスが使用されている）

## 影響範囲

### 変更ファイル
- `.github/workflows/deploy.yml` - working-directoryパスの修正のみ

### 影響を受ける機能
- **AWS CDKデプロイ**: mainブランチへのpush時に実行されるheadless-crawlerのデプロイ処理
- **定期実行ジョブ**: デプロイされるLambda関数による求人情報の自動収集機能

### 影響を受けないもの
- アプリケーションのソースコード（変更なし）
- PR Checksワークフロー（既に正しいパスを使用）
- フロントエンドアプリケーション
- job-store-api
- その他のパッケージ

### テスト・確認事項
- [ ] デプロイワークフローが正常に実行されることを確認
- [ ] CDKデプロイコマンドがエラーなく完了することを確認
- [ ] デプロイされたLambda関数が正常に動作することを確認

※ これらの確認はmainブランチへのマージ後のCI/CDでの実行結果で確認する必要があります
