### PR TITLE
refactor(headless-crawler): デッドレターモニターのGitHub連携機能をヘルパーファイルに分離

### DIFF
--- a/apps/headless-crawler/functions/deadLetterMonitor/handler.ts
+++ b/apps/headless-crawler/functions/deadLetterMonitor/handler.ts
@@ -68,10 +68,12 @@ export const handler = async (_event: ScheduledEvent) => {
             ];
 
             // システム属性
-            const systemAttributes = message.Attributes ? [
-              `**リトライ回数**: ${message.Attributes.ApproximateReceiveCount}`,
-              `**送信時刻**: ${new Date(Number.parseInt(message.Attributes.SentTimestamp || "0")).toISOString()}`,
-            ] : [];
+            const systemAttributes = message.Attributes
+              ? [
+                  `**リトライ回数**: ${message.Attributes.ApproximateReceiveCount}`,
+                  `**送信時刻**: ${new Date(Number.parseInt(message.Attributes.SentTimestamp || "0")).toISOString()}`,
+                ]
+              : [];
 
             if (message.Attributes) {
               console.log(
@@ -91,24 +93,35 @@ export const handler = async (_event: ScheduledEvent) => {
               try {
                 const parsedBody = JSON.parse(message.Body || "") as any;
 
-                const jobIdDetail = parsedBody?.job?.id ? (() => {
-                  console.log("📋 Job ID:", parsedBody.job.id);
-                  return `**Job ID**: ${parsedBody.job.id}`;
-                })() : null;
+                const jobIdDetail = parsedBody?.job?.id
+                  ? (() => {
+                      console.log("📋 Job ID:", parsedBody.job.id);
+                      return `**Job ID**: ${parsedBody.job.id}`;
+                    })()
+                  : null;
 
-                const errorMessageDetail = parsedBody.errorMessage ? (() => {
-                  console.log("🚨 エラー:", parsedBody.errorMessage);
-                  return `**エラー**: ${parsedBody.errorMessage}`;
-                })() : null;
+                const errorMessageDetail = parsedBody.errorMessage
+                  ? (() => {
+                      console.log("🚨 エラー:", parsedBody.errorMessage);
+                      return `**エラー**: ${parsedBody.errorMessage}`;
+                    })()
+                  : null;
 
-                const errorTypeDetail = parsedBody.errorType ? (() => {
-                  console.log("🚨 タイプ:", parsedBody.errorType);
-                  return `**タイプ**: ${parsedBody.errorType}`;
-                })() : null;
+                const errorTypeDetail = parsedBody.errorType
+                  ? (() => {
+                      console.log("🚨 タイプ:", parsedBody.errorType);
+                      return `**タイプ**: ${parsedBody.errorType}`;
+                    })()
+                  : null;
 
                 const jsonDetail = `\n\`\`\`json\n${JSON.stringify(parsedBody, null, 2)}\n\`\`\`\n`;
 
-                return [jobIdDetail, errorMessageDetail, errorTypeDetail, jsonDetail].filter(Boolean);
+                return [
+                  jobIdDetail,
+                  errorMessageDetail,
+                  errorTypeDetail,
+                  jsonDetail,
+                ].filter(Boolean);
               } catch (e) {
                 console.error("メッセージ本文のパースエラー:", e);
                 // JSON形式でない場合はそのまま表示
@@ -116,7 +129,11 @@ export const handler = async (_event: ScheduledEvent) => {
               }
             })();
 
-            const errorSummary = [...basicInfo, ...systemAttributes, ...messageDetails].join('\n');
+            const errorSummary = [
+              ...basicInfo,
+              ...systemAttributes,
+              ...messageDetails,
+            ].join("\n");
 
             return errorSummary;
           });
@@ -124,7 +141,10 @@ export const handler = async (_event: ScheduledEvent) => {
           try {
             const title = `デッドレターキューエラー - ${new Date().toISOString().split("T")[0]} (${messages.Messages.length}件)`;
 
-            await createBugIssue({ title, errorLog: errorDetails.join("\n---\n") });
+            await createBugIssue({
+              title,
+              errorLog: errorDetails.join("\n---\n"),
+            });
           } catch (error) {
             console.error("❌ GitHub Issue作成エラー:", error);
           }

--- a/apps/headless-crawler/functions/deadLetterMonitor/handler.ts
+++ b/apps/headless-crawler/functions/deadLetterMonitor/handler.ts
@@ -3,8 +3,8 @@ import {
   GetQueueAttributesCommand,
   ReceiveMessageCommand,
 } from "@aws-sdk/client-sqs";
-import { Octokit } from "octokit";
 import type { ScheduledEvent } from "aws-lambda";
+import { createBugIssue } from "./helper";
 
 const sqsClient = new SQSClient({
   region: process.env.AWS_REGION || "us-east-1",
@@ -14,9 +14,6 @@ export const handler = async (_event: ScheduledEvent) => {
   console.log("デッドレターキューの監視を開始しました");
 
   const queueUrl = process.env.DEAD_LETTER_QUEUE_URL;
-  const githubToken = process.env.GITHUB_TOKEN;
-  const githubOwner = process.env.GITHUB_OWNER;
-  const githubRepo = process.env.GITHUB_REPO;
 
   if (!queueUrl) {
     console.error("DEAD_LETTER_QUEUE_URL環境変数が設定されていません");
@@ -59,18 +56,23 @@ export const handler = async (_event: ScheduledEvent) => {
             `📨 ${messages.Messages.length}件のメッセージを取得しました:`,
           );
 
-          const errorDetails: string[] = [];
-
-          messages.Messages.forEach((message, index) => {
+          const errorDetails = messages.Messages.map((message, index) => {
             console.log(`\n--- メッセージ ${index + 1} ---`);
             console.log("メッセージID:", message.MessageId);
             console.log("メッセージ本文:", message.Body);
 
             // エラー詳細を収集
-            let errorSummary = `### エラー ${index + 1}\n`;
-            errorSummary += `**メッセージID**: ${message.MessageId}\n`;
+            const basicInfo = [
+              `### エラー ${index + 1}`,
+              `**メッセージID**: ${message.MessageId}`,
+            ];
 
             // システム属性
+            const systemAttributes = message.Attributes ? [
+              `**リトライ回数**: ${message.Attributes.ApproximateReceiveCount}`,
+              `**送信時刻**: ${new Date(Number.parseInt(message.Attributes.SentTimestamp || "0")).toISOString()}`,
+            ] : [];
+
             if (message.Attributes) {
               console.log(
                 "  - 受信回数:",
@@ -82,76 +84,54 @@ export const handler = async (_event: ScheduledEvent) => {
                   Number.parseInt(message.Attributes.SentTimestamp || "0"),
                 ).toISOString(),
               );
-              errorSummary += `**リトライ回数**: ${message.Attributes.ApproximateReceiveCount}\n`;
-              errorSummary += `**送信時刻**: ${new Date(Number.parseInt(message.Attributes.SentTimestamp || "0")).toISOString()}\n`;
             }
 
             // メッセージ本文をJSONとしてパース
-            try {
-              const parsedBody = JSON.parse(message.Body || "");
-              if (parsedBody.errorMessage) {
-                console.log("🚨 エラー:", parsedBody.errorMessage);
-                errorSummary += `**エラー**: ${parsedBody.errorMessage}\n`;
-              }
-              if (parsedBody.errorType) {
-                console.log("🚨 タイプ:", parsedBody.errorType);
-                errorSummary += `**タイプ**: ${parsedBody.errorType}\n`;
-              }
-              errorSummary += `\n\`\`\`json\n${JSON.stringify(parsedBody, null, 2)}\n\`\`\`\n`;
-            } catch (e) {
-              console.error("メッセージ本文のパースエラー:", e);
-              // JSON形式でない場合はそのまま表示
-              errorSummary += `\n\`\`\`\n${message.Body}\n\`\`\`\n`;
-            }
+            const messageDetails = (() => {
+              try {
+                const parsedBody = JSON.parse(message.Body || "") as any;
 
-            errorDetails.push(errorSummary);
+                const jobIdDetail = parsedBody?.job?.id ? (() => {
+                  console.log("📋 Job ID:", parsedBody.job.id);
+                  return `**Job ID**: ${parsedBody.job.id}`;
+                })() : null;
+
+                const errorMessageDetail = parsedBody.errorMessage ? (() => {
+                  console.log("🚨 エラー:", parsedBody.errorMessage);
+                  return `**エラー**: ${parsedBody.errorMessage}`;
+                })() : null;
+
+                const errorTypeDetail = parsedBody.errorType ? (() => {
+                  console.log("🚨 タイプ:", parsedBody.errorType);
+                  return `**タイプ**: ${parsedBody.errorType}`;
+                })() : null;
+
+                const jsonDetail = `\n\`\`\`json\n${JSON.stringify(parsedBody, null, 2)}\n\`\`\`\n`;
+
+                return [jobIdDetail, errorMessageDetail, errorTypeDetail, jsonDetail].filter(Boolean);
+              } catch (e) {
+                console.error("メッセージ本文のパースエラー:", e);
+                // JSON形式でない場合はそのまま表示
+                return [`\n\`\`\`\n${message.Body}\n\`\`\`\n`];
+              }
+            })();
+
+            const errorSummary = [...basicInfo, ...systemAttributes, ...messageDetails].join('\n');
+
+            return errorSummary;
           });
 
-          // GitHub Issue作成
-          if (githubToken && githubOwner && githubRepo) {
-            try {
-              const octokit = new Octokit({ auth: githubToken });
+          try {
+            const title = `デッドレターキューエラー - ${new Date().toISOString().split("T")[0]} (${messages.Messages.length}件)`;
 
-              const title = `デッドレターキューエラー - ${new Date().toISOString().split("T")[0]} (${messages.Messages.length}件)`;
-              const body = `
-## デッドレターキューエラーレポート
-
-**日時**: ${new Date().toLocaleString("ja-JP")}  
-**総メッセージ数**: ${messages.Messages.length}件
-
-## エラー詳細
-
-${errorDetails.join("\n")}
-
-## 対応項目
-- [ ] エラーの根本原因を調査する
-- [ ] 根本的な問題を修正する  
-- [ ] 失敗したメッセージの再処理を検討する
-- [ ] 必要に応じてエラーハンドリングを更新する
-
----
-*デッドレターキューモニターによる自動生成*
-              `.trim();
-
-              const issue = await octokit.rest.issues.create({
-                owner: githubOwner,
-                repo: githubRepo,
-                title,
-                body,
-                labels: ["bug", "dead-letter-queue", "monitoring"],
-              });
-
-              console.log(
-                `✅ GitHub Issueを作成しました: ${issue.data.html_url}`,
-              );
-            } catch (error) {
-              console.error("❌ GitHub Issue作成エラー:", error);
-            }
-          } else {
-            console.log(
-              "⚠️  GitHub連携が設定されていません（トークン/オーナー/リポジトリが不足）",
-            );
+            await createBugIssue({ title, errorLog: errorDetails.join("\n---\n") });
+          } catch (error) {
+            console.error("❌ GitHub Issue作成エラー:", error);
           }
+        } else {
+          console.log(
+            "⚠️  GitHub連携が設定されていません（トークン/オーナー/リポジトリが不足）",
+          );
         }
       } catch (error) {
         console.error("メッセージ取得エラー:", error);

--- a/apps/headless-crawler/functions/deadLetterMonitor/helper.ts
+++ b/apps/headless-crawler/functions/deadLetterMonitor/helper.ts
@@ -1,14 +1,13 @@
 import { Octokit } from "octokit";
 
-
 if (!process.env.GITHUB_TOKEN) {
-    throw new Error("GITHUB_TOKEN is not set");
+  throw new Error("GITHUB_TOKEN is not set");
 }
 
 const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
 
 function generateBugIssueBody({ errorLog }: { errorLog: string }) {
-    return `
+  return `
 ### エラーのログ
 \`\`\`
 ${errorLog}
@@ -16,13 +15,19 @@ ${errorLog}
 `;
 }
 
-export async function createBugIssue({ title, errorLog }: { title: string; errorLog: string; }) {
-    const body = generateBugIssueBody({ errorLog });
-    const response = await octokit.rest.issues.create({
-        owner: "shidari",
-        repo: "hello-work-software-jobs",
-        title,
-        body
-    });
-    console.log("イシュー作成成功:", response.data.html_url);
+export async function createBugIssue({
+  title,
+  errorLog,
+}: {
+  title: string;
+  errorLog: string;
+}) {
+  const body = generateBugIssueBody({ errorLog });
+  const response = await octokit.rest.issues.create({
+    owner: "shidari",
+    repo: "hello-work-software-jobs",
+    title,
+    body,
+  });
+  console.log("イシュー作成成功:", response.data.html_url);
 }

--- a/apps/headless-crawler/functions/deadLetterMonitor/helper.ts
+++ b/apps/headless-crawler/functions/deadLetterMonitor/helper.ts
@@ -1,0 +1,28 @@
+import { Octokit } from "octokit";
+
+
+if (!process.env.GITHUB_TOKEN) {
+    throw new Error("GITHUB_TOKEN is not set");
+}
+
+const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
+
+function generateBugIssueBody({ errorLog }: { errorLog: string }) {
+    return `
+### エラーのログ
+\`\`\`
+${errorLog}
+\`\`\`
+`;
+}
+
+export async function createBugIssue({ title, errorLog }: { title: string; errorLog: string; }) {
+    const body = generateBugIssueBody({ errorLog });
+    const response = await octokit.rest.issues.create({
+        owner: "shidari",
+        repo: "hello-work-software-jobs",
+        title,
+        body
+    });
+    console.log("イシュー作成成功:", response.data.html_url);
+}


### PR DESCRIPTION
## 背景

headless-crawlerシステムの大規模なリアーキテクチャを予定しており、現在のモノリシックな構造では以下の課題がありました：

- 各機能が密結合しており、個別の修正・置換が困難
- 責任範囲が不明確で、アーキテクチャ変更時の影響範囲が予測困難
- 外部サービス連携（GitHub API）がビジネスロジックと混在

## このPRが解決すること

### 🎯 大規模リアーキテクチャへの準備

今後のheadless-crawlerの大規模なリアーキテクチャに向けて、GitHub連携機能を独立したモジュールとして切り出す必要がありました。

1. **モジュール化の推進**: 外部サービス連携を独立したヘルパーとして分離

### 🔧 具体的な変更

- `createBugIssue`関数を新規作成し、GitHub連携を完全に分離
- `handler.ts`からOctokit関連の依存を削除し、純粋なSQS処理に集中
- 環境変数の必須チェック機能を追加し、設定不備を早期検出

## 影響範囲

### 🔍 影響がある箇所

- `apps/headless-crawler/functions/deadLetterMonitor/handler.ts` - GitHub連携コードを削除
- `apps/headless-crawler/functions/deadLetterMonitor/helper.ts` - 新規作成

### 🚀 将来のリアーキテクチャへの効果

今後、ETLで書き換えを予定しており、さらに先を見据えてstoreとcollectorを切り出し、データ収集基盤に移行する計画があります。データ収集基盤はRustで書く予定のため、このモジュール分離により段階的な移行が可能になります。
