### PR TITLE
fix(renovate): minimalReleaseAge を minimumReleaseAge に修正

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,7 @@
       "matchDatasources": [
         "npm"
       ],
-      "minimalReleaseAge": "7 days"
+      "minimumReleaseAge": "7 days"
     }
   ]
 }


### PR DESCRIPTION
- Renovateの正しいプロパティ名に修正
- npm依存関係の最小リリース期間設定（7日）を適切に適用