### PR TITLE
fix: スクリプトパスを修正

### DIFF
--- a/apps/headless-crawler/package.json
+++ b/apps/headless-crawler/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "bootstrap": "aws-vault exec cdk-bootstrap-user -- cdk bootstrap  --cloudformation-execution-policies arn:aws:iam::aws:policy/AdministratorAccess",
     "deploy": "aws-vault exec cdk-deploy -- cdk deploy",
-    "verify:crawler": "ts-node lib/domains/crawler/playground/index.ts",
-    "verify:scraper": "ts-node lib/domains/scraper/playground/index.ts",
+    "verify:crawler": "ts-node lib/crawler/playground/index.ts",
+    "verify:scraper": "ts-node lib/scraper/playground/index.ts",
     "type-check": "pnpm exec tsc --noEmit"
   },
   "devDependencies": {


### PR DESCRIPTION
## 背景
headless-crawlerプロジェクトで検証スクリプト（`verify:crawler`, `verify:scraper`）を実行しようとした際に、ファイルが見つからないエラーが発生していました。

調査の結果、package.jsonで定義されているスクリプトパスが実際のディレクトリ構造と一致していないことが判明しました。スクリプトは`lib/domains/`配下のパスを指していましたが、実際のファイルは`lib/`直下に配置されていました。

## 概要
スクリプトの実行パスを修正しました。

## 変更内容
- `verify:crawler`スクリプトのパスを修正: `lib/domains/crawler/playground/index.ts` → `lib/crawler/playground/index.ts`
- `verify:scraper`スクリプトのパスを修正: `lib/domains/scraper/playground/index.ts` → `lib/scraper/playground/index.ts`

## 修正理由
ディレクトリ構造を間違えていたため、検証スクリプトが実行できない状態でした。正しいパスに修正することで、スクリプトが正常に動作するようになります。

## 影響範囲
- package.jsonのスクリプト定義のみ
- 機能的な変更はなし