### PR TITLE
chore: @types/nodeのバージョンを24.5.2に統一

### DIFF
--- a/apps/headless-crawler/package.json
+++ b/apps/headless-crawler/package.json
@@ -15,7 +15,7 @@
     "@sparticuz/chromium": "^138.0.0",
     "@types/aws-lambda": "^8.10.149",
     "@types/jest": "^29.5.14",
-    "@types/node": "22.18.1",
+    "@types/node": "^24.5.2",
     "aws-cdk": "2.1029.0",
     "esbuild": "^0.25.5",
     "ts-node": "^10.9.2",

--- a/apps/hello-work-job-searcher/package.json
+++ b/apps/hello-work-job-searcher/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.55.0",
-    "@types/node": "^22.0.0",
+    "@types/node": "24.5.2",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "typescript": "^5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,7 +74,7 @@ importers:
         specifier: ^29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: 22.18.1
+        specifier: ^24.5.2
         version: 24.5.2
       aws-cdk:
         specifier: 2.1029.0
@@ -123,7 +123,7 @@ importers:
         specifier: ^1.55.0
         version: 1.55.0
       '@types/node':
-        specifier: ^22.0.0
+        specifier: 24.5.2
         version: 24.5.2
       '@types/react':
         specifier: ^19


### PR DESCRIPTION
🔧 概要
@types/nodeのバージョンを24系に統一してlockfileの一貫性を改善

🎯 背景
PR #300 のマージ時にlockfileのズレでCI/CDエラーが発生
各パッケージで微妙に異なる@types/nodeバージョンがlockfile競合の一因
プルリク単位では問題ないが、マージ時の競合を避けるために統一化
🔧 変更内容
headless-crawler: 22.18.1 → ^24.5.2
hello-work-job-searcher: ^22.0.0 → 24.5.2
[pnpm-lock.yaml](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html): 上記変更を反映
📝 狙い
今後のマージ時のlockfile競合リスクを軽減
とりあえず24系で統一しておけば当面問題なし
細かいバージョン管理よりも運用安定性を重視
✅ 確認
プルリク単位でのCI/CDは正常動作を確認済み
マージ後のlockfile整合性向上を期待