### PR TITLE
WIP: feat: フロントエンド向けスキーマをZodからValibotに部分移行

### DIFF
--- a/apps/hello-work-job-searcher/src/app/components/client/JobFavoriteOverviewList/index.tsx
+++ b/apps/hello-work-job-searcher/src/app/components/client/JobFavoriteOverviewList/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { JobOverviewSchema } from "@sho/models";
+import * as v from "valibot"
 import { useAtomValue, useSetAtom } from "jotai";
 import Link from "next/link";
 import { useEffect } from "react";
@@ -18,7 +19,7 @@ export function FavoriteJobOverviewList() {
       if (!raw) return;
       const parsed = JSON.parse(raw);
       if (!Array.isArray(parsed)) return;
-      const validated = parsed.map((item) => JobOverviewSchema.parse(item));
+      const validated = parsed.map((item) => v.parse(JobOverviewSchema, item));
       setFavoriteJobs(validated);
     } catch {
       // ignore

--- a/packages/models/src/schemas/frontend/index.ts
+++ b/packages/models/src/schemas/frontend/index.ts
@@ -1,20 +1,22 @@
-import z from "zod";
-import { ISODateSchema } from "../common";
+import * as v from "valibot"
 
-export const JobOverviewSchema = z.object({
-  jobNumber: z.string(),
-  companyName: z.string(),
-  workPlace: z.string(),
-  jobTitle: z.string(),
-  employmentType: z.string(), // 後でもっと型を細かくする
-  employeeCount: z.number(),
+const ISODateSchema = v.pipe(v.string(), v.isoTimestamp())
+
+export const JobOverviewSchema = v.object({
+  jobNumber: v.string(),
+  companyName: v.string(),
+  workPlace: v.string(),
+  jobTitle: v.string(),
+  employmentType: v.string(), // 後でもっと型を細かくする
+  employeeCount: v.number(),
   receivedDate: ISODateSchema,
 });
 
-export const JobDetailSchema = JobOverviewSchema.extend({
-  salary: z.string(),
-  jobDescription: z.string(),
-  expiryDate: z.string(),
-  workingHours: z.string(),
-  qualifications: z.string(),
+export const JobDetailSchema = v.object({
+  ...JobOverviewSchema.entries,
+  salary: v.string(),
+  jobDescription: v.string(),
+  expiryDate: v.string(),
+  workingHours: v.string(),
+  qualifications: v.string(),
 });

--- a/packages/models/src/types/frontend/index.ts
+++ b/packages/models/src/types/frontend/index.ts
@@ -1,8 +1,8 @@
-import type z from "zod";
+import type * as v from "valibot"
 import type {
   JobDetailSchema,
   JobOverviewSchema,
 } from "../../schemas/frontend";
 
-export type TJobOverview = z.infer<typeof JobOverviewSchema>;
-export type TJobDetail = z.infer<typeof JobDetailSchema>;
+export type TJobOverview = v.InferOutput<typeof JobOverviewSchema>;
+export type TJobDetail = v.InferOutput<typeof JobDetailSchema>;


### PR DESCRIPTION
hello-work-job-searcher用のフロントエンドスキーマのみをValibotに移行

変更内容:
- フロントエンド用JobOverview/JobDetailスキーマをValibotに変更
- 型推論をv.InferOutputに更新
- JobFavoriteOverviewListのパース処理をv.parseに変更

影響範囲:
- packages/models/src/schemas/frontend/index.ts
- packages/models/src/types/frontend/index.ts
- apps/hello-work-job-searcher/src/app/components/client/JobFavoriteOverviewList/index.tsx

注意: headless-crawler等の他アプリはZodのまま維持