### PR TITLE
refactor: headless-crawlerのバリデーションをzodからvalibotへ移行

### DIFF
--- a/apps/headless-crawler/functions/jobQueueHandler/helper.ts
+++ b/apps/headless-crawler/functions/jobQueueHandler/helper.ts
@@ -81,7 +81,7 @@ export const job2InsertedJob = (job: ScrapedJob) => {
   } = job;
   return Effect.gen(function* () {
     const employeeCount = yield* Effect.try({
-      try: () => transformedEmployeeCountSchema.parse(rawEmploreeCount),
+      try: () => v.parse(transformedEmployeeCountSchema, rawEmploreeCount),
       catch: (e) =>
         new ParseEmployeeCountError({
           message: `parse employee count failed.\n${String(e)}`,
@@ -89,26 +89,26 @@ export const job2InsertedJob = (job: ScrapedJob) => {
     });
     const receivedDate = yield* Effect.try({
       try: () =>
-        transformedJSTReceivedDateToISOStrSchema.parse(rawReceivedDate),
+        v.parse(transformedJSTReceivedDateToISOStrSchema, rawReceivedDate),
       catch: (e) =>
         new ParseReceivedDateError({
           message: `parse received date failed.\n${String(e)}`,
         }),
     });
     const expiryDate = yield* Effect.try({
-      try: () => transformedJSTExpiryDateToISOStrSchema.parse(rawExpiryDate),
+      try: () => v.parse(transformedJSTExpiryDateToISOStrSchema, rawExpiryDate),
       catch: (e) =>
         new ParseExpiryDateError({
           message: `parse expiry date failed.\n${String(e)}`,
         }),
     });
     const { wageMax, wageMin } = yield* Effect.try({
-      try: () => transformedWageSchema.parse(rawWage),
+      try: () => v.parse(transformedWageSchema, rawWage),
       catch: (e) =>
         new ParseWageError({ message: `parse wage failed.\n${String(e)}` }),
     });
     const { workingEndTime, workingStartTime } = yield* Effect.try({
-      try: () => transformedWorkingHoursSchema.parse(rawWorkingHours),
+      try: () => v.parse(transformedWorkingHoursSchema, rawWorkingHours),
       catch: (e) =>
         new ParsedWorkingHoursError({
           message: `parse working hours failed.\n${String(e)}`,

--- a/apps/headless-crawler/lib/core/page/JobDetail/extractors/index.ts
+++ b/apps/headless-crawler/lib/core/page/JobDetail/extractors/index.ts
@@ -1,6 +1,6 @@
 import type { JobDetailPage, JobOverViewList, ScrapedJob } from "@sho/models";
 import { Effect } from "effect";
-import { ZodError } from "zod";
+import * as v from "valibot";
 import {
   ExtractEmployeeCountError,
   ExtractEmployMentTypeError,
@@ -97,7 +97,7 @@ function extractCompanyName(page: JobDetailPage) {
         return text;
       },
       catch: (e) =>
-        e instanceof ZodError
+        e instanceof v.ValiError
           ? new ExtractJobCompanyNameError({
               message: e.message,
             })

--- a/apps/headless-crawler/lib/core/page/JobDetail/validators/index.ts
+++ b/apps/headless-crawler/lib/core/page/JobDetail/validators/index.ts
@@ -45,11 +45,11 @@ export function validateJobNumber(val: unknown) {
       catch: (e) =>
         e instanceof v.ValiError
           ? new JobNumberValidationError({
-            message: e.message,
-          })
+              message: e.message,
+            })
           : new JobNumberValidationError({
-            message: `unexpected error.\n${String(e)}`,
-          }),
+              message: `unexpected error.\n${String(e)}`,
+            }),
     });
   });
 }
@@ -61,8 +61,8 @@ export function validateCompanyName(val: unknown) {
       e instanceof v.ValiError
         ? new CompanyNameValidationError({ message: e.message })
         : new CompanyNameValidationError({
-          message: `unexpected error.\n${String(e)}`,
-        }),
+            message: `unexpected error.\n${String(e)}`,
+          }),
   });
 }
 
@@ -73,8 +73,8 @@ export function validateReceivedDate(val: unknown) {
       e instanceof v.ValiError
         ? new ReceivedDateValidationError({ message: e.message })
         : new ReceivedDateValidationError({
-          message: `unexpected error.\n${String(e)}`,
-        }),
+            message: `unexpected error.\n${String(e)}`,
+          }),
   });
 }
 export function validateExpiryDate(val: unknown) {
@@ -84,8 +84,8 @@ export function validateExpiryDate(val: unknown) {
       e instanceof v.ValiError
         ? new ExpiryDateValidationError({ message: e.message })
         : new ExpiryDateValidationError({
-          message: `unexpected error.\n${String(e)}`,
-        }),
+            message: `unexpected error.\n${String(e)}`,
+          }),
   });
 }
 export function validateHomePage(val: unknown) {
@@ -95,8 +95,8 @@ export function validateHomePage(val: unknown) {
       e instanceof v.ValiError
         ? new HomePageValidationError({ message: e.message })
         : new HomePageValidationError({
-          message: `unexpected error.\n${String(e)}`,
-        }),
+            message: `unexpected error.\n${String(e)}`,
+          }),
   });
 }
 
@@ -111,8 +111,8 @@ export function validateOccupation(val: unknown) {
         e instanceof v.ValiError
           ? new OccupationValidationError({ message: e.message })
           : new OccupationValidationError({
-            message: `unexpected error.\n${String(e)}`,
-          }),
+              message: `unexpected error.\n${String(e)}`,
+            }),
     });
   });
 }
@@ -124,8 +124,8 @@ export function validateEmploymentType(val: unknown) {
       e instanceof v.ValiError
         ? new EmploymentTypeValidationError({ message: e.message })
         : new EmploymentTypeValidationError({
-          message: `unexpected error.\n${String(e)}`,
-        }),
+            message: `unexpected error.\n${String(e)}`,
+          }),
   });
 }
 
@@ -140,8 +140,8 @@ export function validateWage(val: unknown) {
         e instanceof v.ValiError
           ? new WageValidationError({ message: e.message })
           : new WageValidationError({
-            message: `unexpected error.\n${String(e)}`,
-          }),
+              message: `unexpected error.\n${String(e)}`,
+            }),
     });
   });
 }
@@ -153,8 +153,8 @@ export function validateWorkingHours(val: unknown) {
       e instanceof v.ValiError
         ? new WorkingHoursValidationError({ message: e.message })
         : new WorkingHoursValidationError({
-          message: `unexpected error.\n${String(e)}`,
-        }),
+            message: `unexpected error.\n${String(e)}`,
+          }),
   });
 }
 export function validateEmployeeCount(val: unknown) {
@@ -164,8 +164,8 @@ export function validateEmployeeCount(val: unknown) {
       e instanceof v.ValiError
         ? new EmployeeCountValidationError({ message: e.message })
         : new EmployeeCountValidationError({
-          message: `unexpected error.\n${String(e)}`,
-        }),
+            message: `unexpected error.\n${String(e)}`,
+          }),
   });
 }
 
@@ -176,8 +176,8 @@ export function validateWorkPlace(val: unknown) {
       e instanceof v.ValiError
         ? new WorkPlaceValidationError({ message: e.message })
         : new WorkPlaceValidationError({
-          message: `unexpected error. \n${String(e)}`,
-        }),
+            message: `unexpected error. \n${String(e)}`,
+          }),
   });
 }
 
@@ -188,8 +188,8 @@ export function validateJobDescription(val: unknown) {
       e instanceof v.ValiError
         ? new JobDescriptionValidationError({ message: e.message })
         : new JobDescriptionValidationError({
-          message: `unexpected error.\n${String}`,
-        }),
+            message: `unexpected error.\n${String}`,
+          }),
   });
 }
 

--- a/apps/headless-crawler/lib/core/page/JobDetail/validators/index.ts
+++ b/apps/headless-crawler/lib/core/page/JobDetail/validators/index.ts
@@ -17,8 +17,7 @@ import {
 } from "@sho/models";
 import { Effect } from "effect";
 import type { Page } from "playwright";
-import type z from "zod";
-import { ZodError } from "zod";
+import * as v from "valibot";
 import {
   CompanyNameValidationError,
   EmployeeCountValidationError,
@@ -42,62 +41,62 @@ export function validateJobNumber(val: unknown) {
       `calling validateJobNumber. args={val:${JSON.stringify(val, null, 2)}}`,
     );
     return yield* Effect.try({
-      try: () => jobNumberSchema.parse(val),
+      try: () => v.parse(jobNumberSchema, val),
       catch: (e) =>
-        e instanceof ZodError
+        e instanceof v.ValiError
           ? new JobNumberValidationError({
-              message: e.message,
-            })
+            message: e.message,
+          })
           : new JobNumberValidationError({
-              message: `unexpected error.\n${String(e)}`,
-            }),
+            message: `unexpected error.\n${String(e)}`,
+          }),
     });
   });
 }
 
 export function validateCompanyName(val: unknown) {
   return Effect.try({
-    try: () => companyNameSchema.parse(val),
+    try: () => v.parse(companyNameSchema, val),
     catch: (e) =>
-      e instanceof ZodError
+      e instanceof v.ValiError
         ? new CompanyNameValidationError({ message: e.message })
         : new CompanyNameValidationError({
-            message: `unexpected error.\n${String(e)}`,
-          }),
+          message: `unexpected error.\n${String(e)}`,
+        }),
   });
 }
 
 export function validateReceivedDate(val: unknown) {
   return Effect.try({
-    try: () => RawReceivedDateShema.parse(val),
+    try: () => v.parse(RawReceivedDateShema, val),
     catch: (e) =>
-      e instanceof ZodError
+      e instanceof v.ValiError
         ? new ReceivedDateValidationError({ message: e.message })
         : new ReceivedDateValidationError({
-            message: `unexpected error.\n${String(e)}`,
-          }),
+          message: `unexpected error.\n${String(e)}`,
+        }),
   });
 }
 export function validateExpiryDate(val: unknown) {
   return Effect.try({
-    try: () => RawExpiryDateSchema.parse(val),
+    try: () => v.parse(RawExpiryDateSchema, val),
     catch: (e) =>
-      e instanceof ZodError
+      e instanceof v.ValiError
         ? new ExpiryDateValidationError({ message: e.message })
         : new ExpiryDateValidationError({
-            message: `unexpected error.\n${String(e)}`,
-          }),
+          message: `unexpected error.\n${String(e)}`,
+        }),
   });
 }
 export function validateHomePage(val: unknown) {
   return Effect.try({
-    try: () => homePageSchema.parse(val),
+    try: () => v.parse(homePageSchema, val),
     catch: (e) =>
-      e instanceof ZodError
+      e instanceof v.ValiError
         ? new HomePageValidationError({ message: e.message })
         : new HomePageValidationError({
-            message: `unexpected error.\n${String(e)}`,
-          }),
+          message: `unexpected error.\n${String(e)}`,
+        }),
   });
 }
 
@@ -107,26 +106,26 @@ export function validateOccupation(val: unknown) {
       `calling validateOccupation. args=${JSON.stringify(val, null, 2)}`,
     );
     return yield* Effect.try({
-      try: () => occupationSchema.parse(val),
+      try: () => v.parse(occupationSchema, val),
       catch: (e) =>
-        e instanceof ZodError
+        e instanceof v.ValiError
           ? new OccupationValidationError({ message: e.message })
           : new OccupationValidationError({
-              message: `unexpected error.\n${String(e)}`,
-            }),
+            message: `unexpected error.\n${String(e)}`,
+          }),
     });
   });
 }
 
 export function validateEmploymentType(val: unknown) {
   return Effect.try({
-    try: () => employmentTypeSchema.parse(val),
+    try: () => v.parse(employmentTypeSchema, val),
     catch: (e) =>
-      e instanceof ZodError
+      e instanceof v.ValiError
         ? new EmploymentTypeValidationError({ message: e.message })
         : new EmploymentTypeValidationError({
-            message: `unexpected error.\n${String(e)}`,
-          }),
+          message: `unexpected error.\n${String(e)}`,
+        }),
   });
 }
 
@@ -136,77 +135,77 @@ export function validateWage(val: unknown) {
       `calling validateWage. args=${JSON.stringify(val, null, 2)}`,
     );
     return yield* Effect.try({
-      try: () => RawWageSchema.parse(val),
+      try: () => v.parse(RawWageSchema, val),
       catch: (e) =>
-        e instanceof ZodError
+        e instanceof v.ValiError
           ? new WageValidationError({ message: e.message })
           : new WageValidationError({
-              message: `unexpected error.\n${String(e)}`,
-            }),
+            message: `unexpected error.\n${String(e)}`,
+          }),
     });
   });
 }
 
 export function validateWorkingHours(val: unknown) {
   return Effect.try({
-    try: () => RawWorkingHoursSchema.parse(val),
+    try: () => v.parse(RawWorkingHoursSchema, val),
     catch: (e) =>
-      e instanceof ZodError
+      e instanceof v.ValiError
         ? new WorkingHoursValidationError({ message: e.message })
         : new WorkingHoursValidationError({
-            message: `unexpected error.\n${String(e)}`,
-          }),
+          message: `unexpected error.\n${String(e)}`,
+        }),
   });
 }
 export function validateEmployeeCount(val: unknown) {
   return Effect.try({
-    try: () => RawEmployeeCountSchema.parse(val),
+    try: () => v.parse(RawEmployeeCountSchema, val),
     catch: (e) =>
-      e instanceof ZodError
+      e instanceof v.ValiError
         ? new EmployeeCountValidationError({ message: e.message })
         : new EmployeeCountValidationError({
-            message: `unexpected error.\n${String(e)}`,
-          }),
+          message: `unexpected error.\n${String(e)}`,
+        }),
   });
 }
 
 export function validateWorkPlace(val: unknown) {
   return Effect.try({
-    try: () => workPlaceSchema.parse(val),
+    try: () => v.parse(workPlaceSchema, val),
     catch: (e) =>
-      e instanceof ZodError
+      e instanceof v.ValiError
         ? new WorkPlaceValidationError({ message: e.message })
         : new WorkPlaceValidationError({
-            message: `unexpected error. \n${String(e)}`,
-          }),
+          message: `unexpected error. \n${String(e)}`,
+        }),
   });
 }
 
 export function validateJobDescription(val: unknown) {
   return Effect.try({
-    try: () => jobDescriptionSchema.parse(val),
+    try: () => v.parse(jobDescriptionSchema, val),
     catch: (e) =>
-      e instanceof ZodError
+      e instanceof v.ValiError
         ? new JobDescriptionValidationError({ message: e.message })
         : new JobDescriptionValidationError({
-            message: `unexpected error.\n${String}`,
-          }),
+          message: `unexpected error.\n${String}`,
+        }),
   });
 }
 
 export function validateQualification(
   val: unknown,
 ): Effect.Effect<
-  z.infer<typeof qualificationsSchema>,
+  v.InferOutput<typeof qualificationsSchema>,
   QualificationValidationError
 > {
-  const result = qualificationsSchema.safeParse(val);
-  if (result.error) {
+  const result = v.safeParse(qualificationsSchema, val);
+  if (!result.success) {
     return Effect.fail(
-      new QualificationValidationError({ message: result.error.message }),
+      new QualificationValidationError({ message: result.issues.join("\n") }),
     );
   }
-  return Effect.succeed(result.data);
+  return Effect.succeed(result.output);
 }
 export function validateJobDetailPage(
   page: Page,

--- a/apps/headless-crawler/package.json
+++ b/apps/headless-crawler/package.json
@@ -30,7 +30,6 @@
     "effect": "^3.16.5",
     "octokit": "^5.0.3",
     "playwright": "^1.53.1",
-    "valibot": "^1.1.0",
-    "zod": "^4.1.5"
+    "valibot": "^1.1.0"
   }
 }

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -14,8 +14,7 @@
   },
   "dependencies": {
     "drizzle-orm": "^0.44.2",
-    "valibot": "^1.1.0",
-    "zod": "^4.1.5"
+    "valibot": "^1.1.0"
   },
   "devDependencies": {
     "playwright": "^1.53.1",

--- a/packages/models/src/schemas/common.ts
+++ b/packages/models/src/schemas/common.ts
@@ -1,7 +1,3 @@
-import { z } from "zod";
+import * as v from "valibot";
 
-export const ISODateSchema = z
-  .string()
-  .refine((str) => !Number.isNaN(Date.parse(str)), {
-    message: "有効なISO 8601日付ではありません",
-  });
+export const ISODateSchema = v.pipe(v.string(), v.isoTimestamp());

--- a/packages/models/src/schemas/frontend/index.ts
+++ b/packages/models/src/schemas/frontend/index.ts
@@ -1,6 +1,5 @@
 import * as v from "valibot";
-
-const ISODateSchema = v.pipe(v.string(), v.isoTimestamp());
+import { ISODateSchema } from "../common";
 
 export const JobOverviewSchema = v.object({
   jobNumber: v.string(),

--- a/packages/models/src/schemas/headless-crawler/scraper.ts
+++ b/packages/models/src/schemas/headless-crawler/scraper.ts
@@ -1,26 +1,77 @@
 import * as v from "valibot";
-export const jobNumberSchema = v.pipe(v.string(), v.regex(/^\d{5}-\d{0,8}$/), v.brand("jobNumber"));
+export const jobNumberSchema = v.pipe(
+  v.string(),
+  v.regex(/^\d{5}-\d{0,8}$/),
+  v.brand("jobNumber"),
+);
 export const companyNameSchema = v.pipe(v.string(), v.brand("companyName"));
 
-export const homePageSchema = v.pipe(v.string(), v.url("home page should be url"), v.brand("homePage"));
-export const occupationSchema = v.pipe(v.string(), v.minLength(1, "occupation should not be empty."), v.brand("occupation"));
-export const employmentTypeSchema = v.pipe(v.union([v.literal("正社員"), v.literal("パート労働者"), v.literal("正社員以外"), v.literal("有期雇用派遣労働者")]), v.brand("employmentType"));
+export const homePageSchema = v.pipe(
+  v.string(),
+  v.url("home page should be url"),
+  v.brand("homePage"),
+);
+export const occupationSchema = v.pipe(
+  v.string(),
+  v.minLength(1, "occupation should not be empty."),
+  v.brand("occupation"),
+);
+export const employmentTypeSchema = v.pipe(
+  v.union([
+    v.literal("正社員"),
+    v.literal("パート労働者"),
+    v.literal("正社員以外"),
+    v.literal("有期雇用派遣労働者"),
+  ]),
+  v.brand("employmentType"),
+);
 
-export const RawReceivedDateShema = v.pipe(v.string(), v.regex(/^\d{4}年\d{1,2}月\d{1,2}日$/, "received date format invalid. should be yyyy年mm月dd日"), v.brand("receivedDate(raw)"));
+export const RawReceivedDateShema = v.pipe(
+  v.string(),
+  v.regex(
+    /^\d{4}年\d{1,2}月\d{1,2}日$/,
+    "received date format invalid. should be yyyy年mm月dd日",
+  ),
+  v.brand("receivedDate(raw)"),
+);
 
-export const RawExpiryDateSchema = v.pipe(v.string(), v.regex(/^\d{4}年\d{1,2}月\d{1,2}日$/, "expiry date format invalid. should be yyyy年mm月dd日"), v.brand("expiryDate(raw)"));
+export const RawExpiryDateSchema = v.pipe(
+  v.string(),
+  v.regex(
+    /^\d{4}年\d{1,2}月\d{1,2}日$/,
+    "expiry date format invalid. should be yyyy年mm月dd日",
+  ),
+  v.brand("expiryDate(raw)"),
+);
 
-export const RawWageSchema = v.pipe(v.string(), v.minLength(1, "wage should not be empty"), v.brand("wage(raw)"));
+export const RawWageSchema = v.pipe(
+  v.string(),
+  v.minLength(1, "wage should not be empty"),
+  v.brand("wage(raw)"),
+);
 
-export const RawWorkingHoursSchema = v.pipe(v.string(), v.minLength(1, "workingHours should not be empty."), v.brand("workingHours(raw)"));
+export const RawWorkingHoursSchema = v.pipe(
+  v.string(),
+  v.minLength(1, "workingHours should not be empty."),
+  v.brand("workingHours(raw)"),
+);
 
 export const workPlaceSchema = v.pipe(v.string(), v.brand("workPlace"));
 
-export const jobDescriptionSchema = v.pipe(v.string(), v.brand("jobDescription"));
+export const jobDescriptionSchema = v.pipe(
+  v.string(),
+  v.brand("jobDescription"),
+);
 
-export const qualificationsSchema = v.pipe(v.string(), v.brand("qualifications"));
+export const qualificationsSchema = v.pipe(
+  v.string(),
+  v.brand("qualifications"),
+);
 
-export const RawEmployeeCountSchema = v.pipe(v.string(), v.brand("employeeCount(raw)"));
+export const RawEmployeeCountSchema = v.pipe(
+  v.string(),
+  v.brand("employeeCount(raw)"),
+);
 
 const r = Symbol();
 export type TransformedJSTReceivedDateToISOStr = string & { [r]: unknown };
@@ -29,36 +80,59 @@ export type TransformedJSTExpiryDateToISOStr = string & { [e]: unknown };
 const ec = Symbol();
 export type TransformedEmployeeCount = number & { [ec]: unknown };
 
-export const transformedJSTReceivedDateToISOStrSchema = v.pipe(RawReceivedDateShema, v.transform((value) => {
-  // "2025年7月23日" → "2025-07-23"
-  const dateStr = value.replace("年", "-").replace("月", "-").replace("日", "");
-  const isoDate = new Date(dateStr).toISOString();
-  return isoDate;
-}), v.brand("TransformedJSTReceivedDateToISOStr"));
-export const transformedJSTExpiryDateToISOStrSchema = v.pipe(RawExpiryDateSchema, v.transform((value) => {
-  // "2025年7月23日" → "2025-07-23"
-  const dateStr = value.replace("年", "-").replace("月", "-").replace("日", "");
-  const isoDate = new Date(dateStr).toISOString();
-  return isoDate;
-}), v.brand("TransformedJSTExpiryDateToISOStr"));
+export const transformedJSTReceivedDateToISOStrSchema = v.pipe(
+  RawReceivedDateShema,
+  v.transform((value) => {
+    // "2025年7月23日" → "2025-07-23"
+    const dateStr = value
+      .replace("年", "-")
+      .replace("月", "-")
+      .replace("日", "");
+    const isoDate = new Date(dateStr).toISOString();
+    return isoDate;
+  }),
+  v.brand("TransformedJSTReceivedDateToISOStr"),
+);
+export const transformedJSTExpiryDateToISOStrSchema = v.pipe(
+  RawExpiryDateSchema,
+  v.transform((value) => {
+    // "2025年7月23日" → "2025-07-23"
+    const dateStr = value
+      .replace("年", "-")
+      .replace("月", "-")
+      .replace("日", "");
+    const isoDate = new Date(dateStr).toISOString();
+    return isoDate;
+  }),
+  v.brand("TransformedJSTExpiryDateToISOStr"),
+);
 
-export const transformedWageSchema = v.pipe(RawWageSchema, v.transform((value) => {
-  // 直接正規表現を使って上限と下限を抽出し、数値に変換
-  const match = value.match(/^(\d{1,3}(?:,\d{3})*)円〜(\d{1,3}(?:,\d{3})*)円$/);
+export const transformedWageSchema = v.pipe(
+  RawWageSchema,
+  v.transform((value) => {
+    // 直接正規表現を使って上限と下限を抽出し、数値に変換
+    const match = value.match(
+      /^(\d{1,3}(?:,\d{3})*)円〜(\d{1,3}(?:,\d{3})*)円$/,
+    );
 
-  if (!match) {
-    throw new Error("Invalid wage format");
-  }
+    if (!match) {
+      throw new Error("Invalid wage format");
+    }
 
-  // 数字のカンマを削除してから数値に変換
-  const wageMin = Number.parseInt(match[1].replace(/,/g, ""), 10);
-  const wageMax = Number.parseInt(match[2].replace(/,/g, ""), 10);
-  return { wageMin, wageMax }; // 上限と下限の数値オブジェクトを返す
-}), v.check((wage) => !!v.parse(v.object({ wageMin: v.number(), wageMax: v.number() }), wage))); // 後でもうちょっとまともにかく
+    // 数字のカンマを削除してから数値に変換
+    const wageMin = Number.parseInt(match[1].replace(/,/g, ""), 10);
+    const wageMax = Number.parseInt(match[2].replace(/,/g, ""), 10);
+    return { wageMin, wageMax }; // 上限と下限の数値オブジェクトを返す
+  }),
+  v.check(
+    (wage) =>
+      !!v.parse(v.object({ wageMin: v.number(), wageMax: v.number() }), wage),
+  ),
+); // 後でもうちょっとまともにかく
 
-
-export const transformedWorkingHoursSchema = v.pipe(RawWorkingHoursSchema, v.transform(
-  (value) => {
+export const transformedWorkingHoursSchema = v.pipe(
+  RawWorkingHoursSchema,
+  v.transform((value) => {
     const match = value.match(
       /^(\d{1,2})時(\d{1,2})分〜(\d{1,2})時(\d{1,2})分$/,
     );
@@ -72,19 +146,22 @@ export const transformedWorkingHoursSchema = v.pipe(RawWorkingHoursSchema, v.tra
     const workingEndTime = `${endH.padStart(2, "0")}:${endM.padStart(2, "0")}:00`;
 
     return { workingStartTime, workingEndTime };
-  },
-));
+  }),
+);
 
-export const transformedEmployeeCountSchema = v.pipe(RawEmployeeCountSchema, v.transform(
-  (val) => {
+export const transformedEmployeeCountSchema = v.pipe(
+  RawEmployeeCountSchema,
+  v.transform((val) => {
     const match = val.match(/\d+/);
     if (!match) {
       // ここも、後で直す
       return undefined;
     }
     return Number(match[0]);
-  },
-), v.number(), v.brand("TransformedEmployeeCount"));
+  }),
+  v.number(),
+  v.brand("TransformedEmployeeCount"),
+);
 
 export const ScrapedJobSchema = v.object({
   jobNumber: jobNumberSchema,

--- a/packages/models/src/schemas/headless-crawler/scraper.ts
+++ b/packages/models/src/schemas/headless-crawler/scraper.ts
@@ -1,55 +1,26 @@
-import * as z from "zod";
-export const jobNumberSchema = z
-  .string()
-  .regex(/^\d{5}-\d{0,8}$/, "jobNumber format invalid.")
-  .brand("jobNumber");
-export const companyNameSchema = z.string().brand("companyName");
+import * as v from "valibot";
+export const jobNumberSchema = v.pipe(v.string(), v.regex(/^\d{5}-\d{0,8}$/), v.brand("jobNumber"));
+export const companyNameSchema = v.pipe(v.string(), v.brand("companyName"));
 
-export const homePageSchema = z
-  .string()
-  .url("home page should be url")
-  .brand("homePage");
-export const occupationSchema = z
-  .string()
-  .min(1, "occupation should not be empty.")
-  .brand("occupation");
-export const employmentTypeSchema = z
-  .enum(["正社員", "パート労働者", "正社員以外", "有期雇用派遣労働者"])
-  .brand("employmentType");
+export const homePageSchema = v.pipe(v.string(), v.url("home page should be url"), v.brand("homePage"));
+export const occupationSchema = v.pipe(v.string(), v.minLength(1, "occupation should not be empty."), v.brand("occupation"));
+export const employmentTypeSchema = v.pipe(v.union([v.literal("正社員"), v.literal("パート労働者"), v.literal("正社員以外"), v.literal("有期雇用派遣労働者")]), v.brand("employmentType"));
 
-export const RawReceivedDateShema = z
-  .string()
-  .regex(
-    /^\d{4}年\d{1,2}月\d{1,2}日$/,
-    "received date format invalid. should be yyyy年mm月dd日",
-  )
-  .brand("receivedDate(raw)");
+export const RawReceivedDateShema = v.pipe(v.string(), v.regex(/^\d{4}年\d{1,2}月\d{1,2}日$/, "received date format invalid. should be yyyy年mm月dd日"), v.brand("receivedDate(raw)"));
 
-export const RawExpiryDateSchema = z
-  .string()
-  .regex(
-    /^\d{4}年\d{1,2}月\d{1,2}日$/,
-    "expiry date format invalid. should be yyyy年mm月dd日",
-  )
-  .brand("expiryDate(raw)");
+export const RawExpiryDateSchema = v.pipe(v.string(), v.regex(/^\d{4}年\d{1,2}月\d{1,2}日$/, "expiry date format invalid. should be yyyy年mm月dd日"), v.brand("expiryDate(raw)"));
 
-export const RawWageSchema = z
-  .string()
-  .min(1, "wage should not be empty")
-  .brand("wage(raw)");
+export const RawWageSchema = v.pipe(v.string(), v.minLength(1, "wage should not be empty"), v.brand("wage(raw)"));
 
-export const RawWorkingHoursSchema = z
-  .string()
-  .min(1, "workingHours should not be empty.")
-  .brand("workingHours(raw)");
+export const RawWorkingHoursSchema = v.pipe(v.string(), v.minLength(1, "workingHours should not be empty."), v.brand("workingHours(raw)"));
 
-export const workPlaceSchema = z.string().brand("workPlace");
+export const workPlaceSchema = v.pipe(v.string(), v.brand("workPlace"));
 
-export const jobDescriptionSchema = z.string().brand("jobDescription");
+export const jobDescriptionSchema = v.pipe(v.string(), v.brand("jobDescription"));
 
-export const qualificationsSchema = z.string().brand("qualifications");
+export const qualificationsSchema = v.pipe(v.string(), v.brand("qualifications"));
 
-export const RawEmployeeCountSchema = z.string().brand("employeeCount(raw)");
+export const RawEmployeeCountSchema = v.pipe(v.string(), v.brand("employeeCount(raw)"));
 
 const r = Symbol();
 export type TransformedJSTReceivedDateToISOStr = string & { [r]: unknown };
@@ -58,30 +29,20 @@ export type TransformedJSTExpiryDateToISOStr = string & { [e]: unknown };
 const ec = Symbol();
 export type TransformedEmployeeCount = number & { [ec]: unknown };
 
-export const transformedJSTReceivedDateToISOStrSchema =
-  RawReceivedDateShema.transform((value) => {
-    // "2025年7月23日" → "2025-07-23"
-    const dateStr = value
-      .replace("年", "-")
-      .replace("月", "-")
-      .replace("日", "");
+export const transformedJSTReceivedDateToISOStrSchema = v.pipe(RawReceivedDateShema, v.transform((value) => {
+  // "2025年7月23日" → "2025-07-23"
+  const dateStr = value.replace("年", "-").replace("月", "-").replace("日", "");
+  const isoDate = new Date(dateStr).toISOString();
+  return isoDate;
+}), v.brand("TransformedJSTReceivedDateToISOStr"));
+export const transformedJSTExpiryDateToISOStrSchema = v.pipe(RawExpiryDateSchema, v.transform((value) => {
+  // "2025年7月23日" → "2025-07-23"
+  const dateStr = value.replace("年", "-").replace("月", "-").replace("日", "");
+  const isoDate = new Date(dateStr).toISOString();
+  return isoDate;
+}), v.brand("TransformedJSTExpiryDateToISOStr"));
 
-    const isoDate = new Date(dateStr).toISOString();
-    return isoDate;
-  }).brand<TransformedJSTReceivedDateToISOStr>();
-export const transformedJSTExpiryDateToISOStrSchema =
-  RawExpiryDateSchema.transform((value) => {
-    // "2025年7月23日" → "2025-07-23"
-    const dateStr = value
-      .replace("年", "-")
-      .replace("月", "-")
-      .replace("日", "");
-
-    const isoDate = new Date(dateStr).toISOString();
-    return isoDate;
-  }).brand<TransformedJSTExpiryDateToISOStr>();
-
-export const transformedWageSchema = RawWageSchema.transform((value) => {
+export const transformedWageSchema = v.pipe(RawWageSchema, v.transform((value) => {
   // 直接正規表現を使って上限と下限を抽出し、数値に変換
   const match = value.match(/^(\d{1,3}(?:,\d{3})*)円〜(\d{1,3}(?:,\d{3})*)円$/);
 
@@ -93,11 +54,10 @@ export const transformedWageSchema = RawWageSchema.transform((value) => {
   const wageMin = Number.parseInt(match[1].replace(/,/g, ""), 10);
   const wageMax = Number.parseInt(match[2].replace(/,/g, ""), 10);
   return { wageMin, wageMax }; // 上限と下限の数値オブジェクトを返す
-}).refine((wage) =>
-  z.object({ wageMin: z.number(), wageMax: z.number() }).parse(wage),
-);
+}), v.check((wage) => !!v.parse(v.object({ wageMin: v.number(), wageMax: v.number() }), wage))); // 後でもうちょっとまともにかく
 
-export const transformedWorkingHoursSchema = RawWorkingHoursSchema.transform(
+
+export const transformedWorkingHoursSchema = v.pipe(RawWorkingHoursSchema, v.transform(
   (value) => {
     const match = value.match(
       /^(\d{1,2})時(\d{1,2})分〜(\d{1,2})時(\d{1,2})分$/,
@@ -113,37 +73,25 @@ export const transformedWorkingHoursSchema = RawWorkingHoursSchema.transform(
 
     return { workingStartTime, workingEndTime };
   },
-);
+));
 
-export const transformedEmployeeCountSchema = RawEmployeeCountSchema.transform(
-  (val, ctx) => {
+export const transformedEmployeeCountSchema = v.pipe(RawEmployeeCountSchema, v.transform(
+  (val) => {
     const match = val.match(/\d+/);
     if (!match) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "No numeric value found",
-      });
-      return z.NEVER;
+      // ここも、後で直す
+      return undefined;
     }
     return Number(match[0]);
   },
-)
-  .pipe(
-    z
-      .number({
-        // invalid_type_error: "Failed to convert to a number",
-      })
-      .int("Must be an integer")
-      .nonnegative("Must be a non-negative number"),
-  )
-  .brand<TransformedEmployeeCount>();
+), v.number(), v.brand("TransformedEmployeeCount"));
 
-export const ScrapedJobSchema = z.object({
+export const ScrapedJobSchema = v.object({
   jobNumber: jobNumberSchema,
   companyName: companyNameSchema,
   receivedDate: RawReceivedDateShema,
   expiryDate: RawExpiryDateSchema,
-  homePage: homePageSchema.nullable(),
+  homePage: v.nullable(homePageSchema),
   occupation: occupationSchema,
   employmentType: employmentTypeSchema,
   employeeCount: RawEmployeeCountSchema,
@@ -151,5 +99,5 @@ export const ScrapedJobSchema = z.object({
   workingHours: RawWorkingHoursSchema,
   workPlace: workPlaceSchema,
   jobDescription: jobDescriptionSchema,
-  qualifications: qualificationsSchema.nullable(),
+  qualifications: v.nullable(qualificationsSchema),
 });

--- a/packages/models/src/types/headless-crawler/scraper-type.ts
+++ b/packages/models/src/types/headless-crawler/scraper-type.ts
@@ -1,8 +1,8 @@
 import type { Page } from "playwright";
-import type z from "zod";
+import type * as v from "valibot";
 import type { ScrapedJobSchema } from "../../schemas";
 
 const jobDetailPage = Symbol();
 export type JobDetailPage = Page & { [jobDetailPage]: unknown };
 
-export type ScrapedJob = z.infer<typeof ScrapedJobSchema>;
+export type ScrapedJob = v.InferOutput<typeof ScrapedJobSchema>;

--- a/packages/models/src/types/headless-crawler/shared-type.ts
+++ b/packages/models/src/types/headless-crawler/shared-type.ts
@@ -1,5 +1,5 @@
 import type { Locator, Page } from "playwright";
-import type z from "zod";
+import type * as v from "valibot";
 import type { jobNumberSchema } from "../../schemas";
 
 const jobSearchPage = Symbol();
@@ -29,7 +29,7 @@ export type EngineeringLabel = "ソフトウェア開発技術者、プログラ
 type DirtyDesiredOccupation = EngineeringLabel;
 export type SearchPeriod = "all" | "today" | "week";
 
-export type JobNumber = z.infer<typeof jobNumberSchema>;
+export type JobNumber = v.InferOutput<typeof jobNumberSchema>;
 export type JobSearchCriteria = {
   jobNumber?: JobNumber;
   workLocation?: DirtyWorkLocation;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,9 +60,6 @@ importers:
       valibot:
         specifier: ^1.1.0
         version: 1.1.0(typescript@5.9.2)
-      zod:
-        specifier: ^4.1.5
-        version: 4.1.5
     devDependencies:
       '@sparticuz/chromium':
         specifier: ^138.0.0
@@ -207,9 +204,6 @@ importers:
       valibot:
         specifier: ^1.1.0
         version: 1.1.0(typescript@5.9.2)
-      zod:
-        specifier: ^4.1.5
-        version: 4.1.5
     devDependencies:
       playwright:
         specifier: ^1.53.1
@@ -6698,4 +6692,5 @@ snapshots:
 
   zod@3.25.76: {}
 
-  zod@4.1.5: {}
+  zod@4.1.5:
+    optional: true


### PR DESCRIPTION
## 背景

これまで `headless-crawler` 配下のバリデーションには `zod` を利用していましたが、プロジェクト全体の型・バリデーション統一や、今後の保守性・拡張性向上のため、`valibot` への移行を検討していました。

## 目的

- バリデーションロジック・型定義を `valibot` に統一し、保守性・可読性を向上させる
- `zod` 依存を排除し、依存パッケージを整理する
- バリデーションAPIの一貫性を担保し、今後の開発効率を高める

## 影響範囲

- `apps/headless-crawler` 配下の全バリデーションスキーマ・型定義
- バリデーション処理（parse, safeParse, エラー処理等）の `valibot` API への書き換え
- `zod` の import・型・エラー判定の削除
- スキーマ・型定義ファイルの `valibot` 構文へのリファクタ
- `package.json` および `pnpm-lock.yaml` から `zod` 依存の削除

## テスト

- 今回は静的テスト（型チェック・ビルド・lint等）のみ実施

## 備考

- 今回は `headless-crawler` 配下のみの移行です。他パッケージへの影響はありません
- 追加のバリデーション要件や型定義の改善があれば、今後も `valibot` ベースで対応予定です
- 今後は腐食防止層（防御的プログラミングや型安全の強化など）の検討も視野に入れていますが、やりすぎかもしれません