### PR TITLE
refactor(headless-crawler): バリデータでsafeParseを利用しエラーハンドリングを改善

### DIFF
--- a/apps/headless-crawler/lib/core/page/JobDetail/validators/index.ts
+++ b/apps/headless-crawler/lib/core/page/JobDetail/validators/index.ts
@@ -49,9 +49,11 @@ export function validateJobNumber(val: unknown) {
           2,
         )}`,
       );
-      return yield* Effect.fail(new JobNumberValidationError({
-        message: result.issues.join("\n"),
-      }))
+      return yield* Effect.fail(
+        new JobNumberValidationError({
+          message: result.issues.join("\n"),
+        }),
+      );
     }
     return yield* Effect.succeed(result.output);
   });
@@ -105,7 +107,9 @@ export function validateOccupation(val: unknown) {
       yield* Effect.logDebug(
         `failed to validate occupation. issues=${JSON.stringify(result.issues, null, 2)}`,
       );
-      return yield* Effect.fail(new OccupationValidationError({ message: result.issues.join("\n") }))
+      return yield* Effect.fail(
+        new OccupationValidationError({ message: result.issues.join("\n") }),
+      );
     }
     yield* Effect.logDebug(
       `succeeded to validate occupation. val=${JSON.stringify(result.output, null, 2)}`,
@@ -121,8 +125,8 @@ export function validateEmploymentType(val: unknown) {
       e instanceof v.ValiError
         ? new EmploymentTypeValidationError({ message: e.message })
         : new EmploymentTypeValidationError({
-          message: `unexpected error.\n${String(e)}`,
-        }),
+            message: `unexpected error.\n${String(e)}`,
+          }),
   });
 }
 
@@ -137,8 +141,8 @@ export function validateWage(val: unknown) {
         e instanceof v.ValiError
           ? new WageValidationError({ message: e.message })
           : new WageValidationError({
-            message: `unexpected error.\n${String(e)}`,
-          }),
+              message: `unexpected error.\n${String(e)}`,
+            }),
     });
   });
 }
@@ -150,8 +154,8 @@ export function validateWorkingHours(val: unknown) {
       e instanceof v.ValiError
         ? new WorkingHoursValidationError({ message: e.message })
         : new WorkingHoursValidationError({
-          message: `unexpected error.\n${String(e)}`,
-        }),
+            message: `unexpected error.\n${String(e)}`,
+          }),
   });
 }
 export function validateEmployeeCount(val: unknown) {
@@ -161,8 +165,8 @@ export function validateEmployeeCount(val: unknown) {
       e instanceof v.ValiError
         ? new EmployeeCountValidationError({ message: e.message })
         : new EmployeeCountValidationError({
-          message: `unexpected error.\n${String(e)}`,
-        }),
+            message: `unexpected error.\n${String(e)}`,
+          }),
   });
 }
 
@@ -173,8 +177,8 @@ export function validateWorkPlace(val: unknown) {
       e instanceof v.ValiError
         ? new WorkPlaceValidationError({ message: e.message })
         : new WorkPlaceValidationError({
-          message: `unexpected error. \n${String(e)}`,
-        }),
+            message: `unexpected error. \n${String(e)}`,
+          }),
   });
 }
 
@@ -185,8 +189,8 @@ export function validateJobDescription(val: unknown) {
       e instanceof v.ValiError
         ? new JobDescriptionValidationError({ message: e.message })
         : new JobDescriptionValidationError({
-          message: `unexpected error.\n${String}`,
-        }),
+            message: `unexpected error.\n${String}`,
+          }),
   });
 }
 

--- a/apps/headless-crawler/lib/core/page/JobDetail/validators/index.ts
+++ b/apps/headless-crawler/lib/core/page/JobDetail/validators/index.ts
@@ -40,64 +40,59 @@ export function validateJobNumber(val: unknown) {
     yield* Effect.logDebug(
       `calling validateJobNumber. args={val:${JSON.stringify(val, null, 2)}}`,
     );
-    return yield* Effect.try({
-      try: () => v.parse(jobNumberSchema, val),
-      catch: (e) =>
-        e instanceof v.ValiError
-          ? new JobNumberValidationError({
-              message: e.message,
-            })
-          : new JobNumberValidationError({
-              message: `unexpected error.\n${String(e)}`,
-            }),
-    });
+    const result = v.safeParse(jobNumberSchema, val);
+    if (!result.success) {
+      yield* Effect.logDebug(
+        `succeeded to validate jobNumber. val=${JSON.stringify(
+          result.output,
+          null,
+          2,
+        )}`,
+      );
+      return yield* Effect.fail(new JobNumberValidationError({
+        message: result.issues.join("\n"),
+      }))
+    }
+    return yield* Effect.succeed(result.output);
   });
 }
 
 export function validateCompanyName(val: unknown) {
-  return Effect.try({
-    try: () => v.parse(companyNameSchema, val),
-    catch: (e) =>
-      e instanceof v.ValiError
-        ? new CompanyNameValidationError({ message: e.message })
-        : new CompanyNameValidationError({
-            message: `unexpected error.\n${String(e)}`,
-          }),
-  });
+  const result = v.safeParse(companyNameSchema, val);
+  if (!result.success) {
+    return Effect.fail(
+      new CompanyNameValidationError({ message: result.issues.join("\n") }),
+    );
+  }
+  return Effect.succeed(result.output);
 }
 
 export function validateReceivedDate(val: unknown) {
-  return Effect.try({
-    try: () => v.parse(RawReceivedDateShema, val),
-    catch: (e) =>
-      e instanceof v.ValiError
-        ? new ReceivedDateValidationError({ message: e.message })
-        : new ReceivedDateValidationError({
-            message: `unexpected error.\n${String(e)}`,
-          }),
-  });
+  const result = v.safeParse(RawReceivedDateShema, val);
+  if (!result.success) {
+    return Effect.fail(
+      new ReceivedDateValidationError({ message: result.issues.join("\n") }),
+    );
+  }
+  return Effect.succeed(result.output);
 }
 export function validateExpiryDate(val: unknown) {
-  return Effect.try({
-    try: () => v.parse(RawExpiryDateSchema, val),
-    catch: (e) =>
-      e instanceof v.ValiError
-        ? new ExpiryDateValidationError({ message: e.message })
-        : new ExpiryDateValidationError({
-            message: `unexpected error.\n${String(e)}`,
-          }),
-  });
+  const result = v.safeParse(RawExpiryDateSchema, val);
+  if (!result.success) {
+    return Effect.fail(
+      new ExpiryDateValidationError({ message: result.issues.join("\n") }),
+    );
+  }
+  return Effect.succeed(result.output);
 }
 export function validateHomePage(val: unknown) {
-  return Effect.try({
-    try: () => v.parse(homePageSchema, val),
-    catch: (e) =>
-      e instanceof v.ValiError
-        ? new HomePageValidationError({ message: e.message })
-        : new HomePageValidationError({
-            message: `unexpected error.\n${String(e)}`,
-          }),
-  });
+  const result = v.safeParse(homePageSchema, val);
+  if (!result.success) {
+    return Effect.fail(
+      new HomePageValidationError({ message: result.issues.join("\n") }),
+    );
+  }
+  return Effect.succeed(result.output);
 }
 
 export function validateOccupation(val: unknown) {
@@ -105,15 +100,17 @@ export function validateOccupation(val: unknown) {
     yield* Effect.logDebug(
       `calling validateOccupation. args=${JSON.stringify(val, null, 2)}`,
     );
-    return yield* Effect.try({
-      try: () => v.parse(occupationSchema, val),
-      catch: (e) =>
-        e instanceof v.ValiError
-          ? new OccupationValidationError({ message: e.message })
-          : new OccupationValidationError({
-              message: `unexpected error.\n${String(e)}`,
-            }),
-    });
+    const result = v.safeParse(occupationSchema, val);
+    if (!result.success) {
+      yield* Effect.logDebug(
+        `failed to validate occupation. issues=${JSON.stringify(result.issues, null, 2)}`,
+      );
+      return yield* Effect.fail(new OccupationValidationError({ message: result.issues.join("\n") }))
+    }
+    yield* Effect.logDebug(
+      `succeeded to validate occupation. val=${JSON.stringify(result.output, null, 2)}`,
+    );
+    return yield* Effect.succeed(result.output);
   });
 }
 
@@ -124,8 +121,8 @@ export function validateEmploymentType(val: unknown) {
       e instanceof v.ValiError
         ? new EmploymentTypeValidationError({ message: e.message })
         : new EmploymentTypeValidationError({
-            message: `unexpected error.\n${String(e)}`,
-          }),
+          message: `unexpected error.\n${String(e)}`,
+        }),
   });
 }
 
@@ -140,8 +137,8 @@ export function validateWage(val: unknown) {
         e instanceof v.ValiError
           ? new WageValidationError({ message: e.message })
           : new WageValidationError({
-              message: `unexpected error.\n${String(e)}`,
-            }),
+            message: `unexpected error.\n${String(e)}`,
+          }),
     });
   });
 }
@@ -153,8 +150,8 @@ export function validateWorkingHours(val: unknown) {
       e instanceof v.ValiError
         ? new WorkingHoursValidationError({ message: e.message })
         : new WorkingHoursValidationError({
-            message: `unexpected error.\n${String(e)}`,
-          }),
+          message: `unexpected error.\n${String(e)}`,
+        }),
   });
 }
 export function validateEmployeeCount(val: unknown) {
@@ -164,8 +161,8 @@ export function validateEmployeeCount(val: unknown) {
       e instanceof v.ValiError
         ? new EmployeeCountValidationError({ message: e.message })
         : new EmployeeCountValidationError({
-            message: `unexpected error.\n${String(e)}`,
-          }),
+          message: `unexpected error.\n${String(e)}`,
+        }),
   });
 }
 
@@ -176,8 +173,8 @@ export function validateWorkPlace(val: unknown) {
       e instanceof v.ValiError
         ? new WorkPlaceValidationError({ message: e.message })
         : new WorkPlaceValidationError({
-            message: `unexpected error. \n${String(e)}`,
-          }),
+          message: `unexpected error. \n${String(e)}`,
+        }),
   });
 }
 
@@ -188,8 +185,8 @@ export function validateJobDescription(val: unknown) {
       e instanceof v.ValiError
         ? new JobDescriptionValidationError({ message: e.message })
         : new JobDescriptionValidationError({
-            message: `unexpected error.\n${String}`,
-          }),
+          message: `unexpected error.\n${String}`,
+        }),
   });
 }
 


### PR DESCRIPTION
## 背景

これまでバリデーション関数では throwable な `parse` を利用しており、予期しない例外が発生するリスクがありました。expected な parse に対して、unexpected な例外を持ち込みたくないという意図から、より安全な `v.safeParse` への置き換えを行いました。

## このPRでやること

- バリデーション関数の実装を `Effect.try` から `v.safeParse` へ置き換え
- バリデーション失敗時のエラーメッセージとログ出力の改善

## 影響範囲

- `apps/headless-crawler/lib/core/page/JobDetail/validators/index.ts` のバリデーション関数
- バリデーションエラー時の挙動・ログ出力

## テスト

- 静的テストのみ実施（型チェック・ビルド確認）

## 備考

- 外部インターフェースの変更はありません
- 今後、ユニットテストや他バリデーション関数への適用も検討予定