### PR TITLE
chore(hello-work-software-jobs): package.json から packageManager を削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "packageManager": "pnpm@10.17.0",
   "devDependencies": {
     "@biomejs/biome": "^2.0.6",
     "@commitlint/cli": "^19.8.1",


### PR DESCRIPTION
## 背景
https://github.com/shidari/hello-work-software-jobs/pull/304 でCI/CDと `package.json` のパッケージマネージャ（pnpm）のバージョンに不整合が発生していました。

## このPRで解決すること
- `hello-work-software-jobs/package.json` から `packageManager` フィールドを削除し、不整合を解消します。

## 影響範囲
- `hello-work-software-jobs` ディレクトリ配下の `package.json` のみ影響します。
- 他のパッケージやアプリケーションには影響ありません。

## 備考
- 今後、パッケージマネージャーのバージョン管理が必要な場合は、CI/CD側の設定と合わせて管理してください。