### PR TITLE
feat(headless-crawler): 求人番号から求人詳細HTMLを抽出するLambda・Queue・関連処理を追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,7 @@ jobs:
           JOB_STORE_ENDPOINT: ${{ secrets.JOB_STORE_ENDPOINT }}
           MAIL_ADDRESS: ${{ secrets.MAIL_ADDRESS }}
           QUEUE_URL: ${{ secrets.QUEUE_URL }}
+          RAW_JOB_DETAIL_EXTRACTOR_QUEUE_URL: ${{ secrets.RAW_JOB_DETAIL_EXTRACTOR_QUEUE_URL }}
           API_KEY: ${{ secrets.API_KEY }}
           GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN }}
         run: |

--- a/apps/headless-crawler/functions/helpers/helper.ts
+++ b/apps/headless-crawler/functions/helpers/helper.ts
@@ -26,7 +26,9 @@ export const sendJobToQueue = (job: JobMetadata) =>
 export const sendJobToRawJobDetailExtractorQueue = (job: JobMetadata) =>
   Effect.gen(function* () {
     const sqs = new SQSClient({});
-    const QUEUE_URL = yield* Effect.fromNullable(process.env.RAW_JOB_DETAIL_EXTRACTOR_QUEUE_URL);
+    const QUEUE_URL = yield* Effect.fromNullable(
+      process.env.RAW_JOB_DETAIL_EXTRACTOR_QUEUE_URL,
+    );
     return yield* Effect.tryPromise({
       try: async () => {
         return await sqs.send(

--- a/apps/headless-crawler/functions/helpers/helper.ts
+++ b/apps/headless-crawler/functions/helpers/helper.ts
@@ -23,3 +23,23 @@ export const sendJobToQueue = (job: JobMetadata) =>
         new SendSQSMessageError({ message: `unexpected error.\n${String(e)}` }),
     });
   });
+export const sendJobToRawJobDetailExtractorQueue = (job: JobMetadata) =>
+  Effect.gen(function* () {
+    const sqs = new SQSClient({});
+    const QUEUE_URL = yield* Effect.fromNullable(process.env.RAW_JOB_DETAIL_EXTRACTOR_QUEUE_URL);
+    return yield* Effect.tryPromise({
+      try: async () => {
+        return await sqs.send(
+          new SendMessageCommand({
+            QueueUrl: QUEUE_URL,
+            MessageBody: JSON.stringify({
+              job,
+              timestamp: new Date().toISOString(),
+            }),
+          }),
+        );
+      },
+      catch: (e) =>
+        new SendSQSMessageError({ message: `unexpected error.\n${String(e)}` }),
+    });
+  });

--- a/apps/headless-crawler/functions/rawJobDetailExtracter/handler.ts
+++ b/apps/headless-crawler/functions/rawJobDetailExtracter/handler.ts
@@ -4,15 +4,15 @@ import { extractJobDetailRawHtml } from "../../lib/rawJobDetailExtractor";
 import { eventToFirstRecordToJobNumber } from "../extractTransformAndSaveJobDetailHandler/helper";
 
 export const handler: SQSHandler = async (event: SQSEvent) => {
-    const effect = Effect.gen(function* () {
-        const jobNumber = yield* eventToFirstRecordToJobNumber(event);
-        const rawHtml = yield* extractJobDetailRawHtml(jobNumber);
-        return rawHtml
-    });
-    const result = await Effect.runPromiseExit(effect);
-    if (Exit.isSuccess(result)) {
-        console.log("Lambda job succeeded:", result.value);
-    } else {
-        console.error("Lambda job failed", result.cause);
-    }
+  const effect = Effect.gen(function* () {
+    const jobNumber = yield* eventToFirstRecordToJobNumber(event);
+    const rawHtml = yield* extractJobDetailRawHtml(jobNumber);
+    return rawHtml;
+  });
+  const result = await Effect.runPromiseExit(effect);
+  if (Exit.isSuccess(result)) {
+    console.log("Lambda job succeeded:", result.value);
+  } else {
+    console.error("Lambda job failed", result.cause);
+  }
 };

--- a/apps/headless-crawler/functions/rawJobDetailExtracter/handler.ts
+++ b/apps/headless-crawler/functions/rawJobDetailExtracter/handler.ts
@@ -1,0 +1,18 @@
+import type { SQSEvent, SQSHandler } from "aws-lambda";
+import { Effect, Exit } from "effect";
+import { extractJobDetailRawHtml } from "../../lib/rawJobDetailExtractor";
+import { eventToFirstRecordToJobNumber } from "../extractTransformAndSaveJobDetailHandler/helper";
+
+export const handler: SQSHandler = async (event: SQSEvent) => {
+    const effect = Effect.gen(function* () {
+        const jobNumber = yield* eventToFirstRecordToJobNumber(event);
+        const rawHtml = yield* extractJobDetailRawHtml(jobNumber);
+        return rawHtml
+    });
+    const result = await Effect.runPromiseExit(effect);
+    if (Exit.isSuccess(result)) {
+        console.log("Lambda job succeeded:", result.value);
+    } else {
+        console.error("Lambda job failed", result.cause);
+    }
+};

--- a/apps/headless-crawler/infra/constructs/jobDetailRawHtmlExtractor.ts
+++ b/apps/headless-crawler/infra/constructs/jobDetailRawHtmlExtractor.ts
@@ -1,0 +1,66 @@
+// constructs/lambda-construct.ts
+import { Construct } from "constructs";
+import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import { Duration } from "aws-cdk-lib";
+import { Alarm, Metric } from "aws-cdk-lib/aws-cloudwatch";
+import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
+import { Topic } from "aws-cdk-lib/aws-sns";
+import { EmailSubscription } from "aws-cdk-lib/aws-sns-subscriptions";
+
+export class JobDetailRawHtmlExtractorConstruct extends Construct {
+    public readonly extractor: NodejsFunction;
+    constructor(
+        scope: Construct,
+        id: string,
+        props: { playwrightLayer: lambda.LayerVersion },
+    ) {
+        super(scope, id);
+        this.extractor = new NodejsFunction(this, id, {
+            entry: "functions/rawJobDetailExtracter/handler.ts",
+            handler: "handler",
+            runtime: lambda.Runtime.NODEJS_22_X,
+            memorySize: 1024,
+            timeout: Duration.seconds(30),
+            layers: [props.playwrightLayer],
+            bundling: {
+                externalModules: [
+                    "chromium-bidi/lib/cjs/bidiMapper/BidiMapper",
+                    "chromium-bidi/lib/cjs/cdp/CdpConnection",
+                    "@sparticuz/chromium",
+                    "./chromium/appIcon.png",
+                    "./loader",
+                    "playwright-core",
+                ], // Layer に含めるモジュールは除外
+            },
+            environment: {
+                JOB_STORE_ENDPOINT: process.env.JOB_STORE_ENDPOINT || "",
+                API_KEY: process.env.API_KEY || "",
+            },
+        });
+
+        const alarmTopic = new Topic(this, `${id}-alarmTopic`);
+        alarmTopic.addSubscription(
+            new EmailSubscription(process.env.MAIL_ADDRESS || ""),
+        );
+
+        const invocationMetric = new Metric({
+            namespace: "AWS/Lambda",
+            metricName: "Invocations",
+            statistic: "Sum",
+            period: Duration.hours(1),
+            dimensionsMap: {
+                FunctionName: this.extractor.functionName,
+            },
+        });
+
+        const alarm = new Alarm(this, `${id}-invocation-alarm`, {
+            metric: invocationMetric,
+            threshold: 1000,
+            evaluationPeriods: 1,
+            alarmDescription: "scraping Lambda invocation count exceeded threshold",
+        });
+
+        alarm.addAlarmAction(new SnsAction(alarmTopic));
+    }
+}

--- a/apps/headless-crawler/infra/constructs/jobDetailRawHtmlExtractor.ts
+++ b/apps/headless-crawler/infra/constructs/jobDetailRawHtmlExtractor.ts
@@ -9,58 +9,58 @@ import { Topic } from "aws-cdk-lib/aws-sns";
 import { EmailSubscription } from "aws-cdk-lib/aws-sns-subscriptions";
 
 export class JobDetailRawHtmlExtractorConstruct extends Construct {
-    public readonly extractor: NodejsFunction;
-    constructor(
-        scope: Construct,
-        id: string,
-        props: { playwrightLayer: lambda.LayerVersion },
-    ) {
-        super(scope, id);
-        this.extractor = new NodejsFunction(this, id, {
-            entry: "functions/rawJobDetailExtracter/handler.ts",
-            handler: "handler",
-            runtime: lambda.Runtime.NODEJS_22_X,
-            memorySize: 1024,
-            timeout: Duration.seconds(30),
-            layers: [props.playwrightLayer],
-            bundling: {
-                externalModules: [
-                    "chromium-bidi/lib/cjs/bidiMapper/BidiMapper",
-                    "chromium-bidi/lib/cjs/cdp/CdpConnection",
-                    "@sparticuz/chromium",
-                    "./chromium/appIcon.png",
-                    "./loader",
-                    "playwright-core",
-                ], // Layer に含めるモジュールは除外
-            },
-            environment: {
-                JOB_STORE_ENDPOINT: process.env.JOB_STORE_ENDPOINT || "",
-                API_KEY: process.env.API_KEY || "",
-            },
-        });
+  public readonly extractor: NodejsFunction;
+  constructor(
+    scope: Construct,
+    id: string,
+    props: { playwrightLayer: lambda.LayerVersion },
+  ) {
+    super(scope, id);
+    this.extractor = new NodejsFunction(this, id, {
+      entry: "functions/rawJobDetailExtracter/handler.ts",
+      handler: "handler",
+      runtime: lambda.Runtime.NODEJS_22_X,
+      memorySize: 1024,
+      timeout: Duration.seconds(30),
+      layers: [props.playwrightLayer],
+      bundling: {
+        externalModules: [
+          "chromium-bidi/lib/cjs/bidiMapper/BidiMapper",
+          "chromium-bidi/lib/cjs/cdp/CdpConnection",
+          "@sparticuz/chromium",
+          "./chromium/appIcon.png",
+          "./loader",
+          "playwright-core",
+        ], // Layer に含めるモジュールは除外
+      },
+      environment: {
+        JOB_STORE_ENDPOINT: process.env.JOB_STORE_ENDPOINT || "",
+        API_KEY: process.env.API_KEY || "",
+      },
+    });
 
-        const alarmTopic = new Topic(this, `${id}-alarmTopic`);
-        alarmTopic.addSubscription(
-            new EmailSubscription(process.env.MAIL_ADDRESS || ""),
-        );
+    const alarmTopic = new Topic(this, `${id}-alarmTopic`);
+    alarmTopic.addSubscription(
+      new EmailSubscription(process.env.MAIL_ADDRESS || ""),
+    );
 
-        const invocationMetric = new Metric({
-            namespace: "AWS/Lambda",
-            metricName: "Invocations",
-            statistic: "Sum",
-            period: Duration.hours(1),
-            dimensionsMap: {
-                FunctionName: this.extractor.functionName,
-            },
-        });
+    const invocationMetric = new Metric({
+      namespace: "AWS/Lambda",
+      metricName: "Invocations",
+      statistic: "Sum",
+      period: Duration.hours(1),
+      dimensionsMap: {
+        FunctionName: this.extractor.functionName,
+      },
+    });
 
-        const alarm = new Alarm(this, `${id}-invocation-alarm`, {
-            metric: invocationMetric,
-            threshold: 1000,
-            evaluationPeriods: 1,
-            alarmDescription: "scraping Lambda invocation count exceeded threshold",
-        });
+    const alarm = new Alarm(this, `${id}-invocation-alarm`, {
+      metric: invocationMetric,
+      threshold: 1000,
+      evaluationPeriods: 1,
+      alarmDescription: "scraping Lambda invocation count exceeded threshold",
+    });
 
-        alarm.addAlarmAction(new SnsAction(alarmTopic));
-    }
+    alarm.addAlarmAction(new SnsAction(alarmTopic));
+  }
 }

--- a/apps/headless-crawler/infra/stacks/headless-crawler-stack.ts
+++ b/apps/headless-crawler/infra/stacks/headless-crawler-stack.ts
@@ -42,9 +42,13 @@ export class HeadlessCrawlerStack extends cdk.Stack {
       },
     );
 
-    const jobDetailRawHtmlExtractor = new JobDetailRawHtmlExtractorConstruct(this, "JobDetailRawHtmlExtractor", {
-      playwrightLayer: playwrightLayer.layer,
-    });
+    const jobDetailRawHtmlExtractor = new JobDetailRawHtmlExtractorConstruct(
+      this,
+      "JobDetailRawHtmlExtractor",
+      {
+        playwrightLayer: playwrightLayer.layer,
+      },
+    );
 
     // デッドレターキューを作成
     const deadLetterQueue = new sqs.Queue(this, "ScrapingJobDeadLetterQueue", {
@@ -61,9 +65,11 @@ export class HeadlessCrawlerStack extends cdk.Stack {
       },
     });
 
-    const queueForJobDetailRawHtmlExtractor = new sqs.Queue(this, "JobDetailRawHtmlExtractorQueue", {
-    });
-
+    const queueForJobDetailRawHtmlExtractor = new sqs.Queue(
+      this,
+      "JobDetailRawHtmlExtractorQueue",
+      {},
+    );
 
     // EventBridgeルール(Cron)を作成（例: 毎日午前1時に実行）
     const rule = new events.Rule(this, "CrawlerScheduleRule", {
@@ -135,6 +141,8 @@ export class HeadlessCrawlerStack extends cdk.Stack {
     rule.addTarget(new targets.LambdaFunction(jobNumberExtractor.extractor));
 
     queue.grantSendMessages(jobNumberExtractor.extractor);
-    queueForJobDetailRawHtmlExtractor.grantSendMessages(jobNumberExtractor.extractor);
+    queueForJobDetailRawHtmlExtractor.grantSendMessages(
+      jobNumberExtractor.extractor,
+    );
   }
 }

--- a/apps/headless-crawler/lib/rawJobDetailExtractor/context.ts
+++ b/apps/headless-crawler/lib/rawJobDetailExtractor/context.ts
@@ -1,0 +1,95 @@
+import type { JobNumber } from "@sho/models";
+import { Context, Data, Effect, Layer } from "effect";
+import {
+    createContext,
+    createPage,
+    launchBrowser,
+} from "../core/headless-browser";
+import type { NewPageError } from "../core/headless-browser/error";
+import type { HelloWorkScrapingConfig } from "../config/scraper";
+import type { JobListPageValidationError } from "../core/page/JobList/validators/error";
+import type { JobSearchPageValidationError } from "../core/page/JobSearch/validators/error";
+import type { ListJobsError } from "../core/page/JobList/others/error";
+import type { AssertSingleJobListedError } from "../core/page/JobList/assertions/error";
+import type {
+    GoToJobSearchPageError,
+    SearchThenGotoFirstJobListPageError,
+} from "../core/page/JobSearch/navigations/error";
+import type { FromJobListToJobDetailPageError } from "../core/page/JobList/navigations/error";
+import type { JobSearchWithJobNumberFillingError } from "../core/page/JobSearch/form-fillings/error";
+import {
+    goToJobSearchPage,
+    searchNoThenGotoSingleJobListPage,
+} from "../core/page/JobSearch/navigations";
+import { goToSingleJobDetailPage } from "../core/page/JobList/navigations";
+import { validateJobDetailPage } from "../core/page/JobDetail/validators";
+import type {
+    JobDetailPageValidationError,
+    JobDetailPropertyValidationError,
+} from "../core/page/JobDetail/validators/error";
+import { validateJobSearchPage } from "../core/page/JobSearch/validators";
+import { validateJobListPage } from "../core/page/JobList/validators";
+
+export class HelloWorkRawJobDetailHtmlExtractor extends Context.Tag("HelloWorkRawJobDetailHtmlExtractor")<
+    HelloWorkRawJobDetailHtmlExtractor,
+    {
+        readonly extractRawHtml: (
+            jobNumber: JobNumber,
+        ) => Effect.Effect<
+            string,
+            | ListJobsError
+            | ExtractJobDetailRawHtmlError
+            | NewPageError
+            | AssertSingleJobListedError
+            | GoToJobSearchPageError
+            | SearchThenGotoFirstJobListPageError
+            | FromJobListToJobDetailPageError
+            | JobSearchPageValidationError
+            | JobListPageValidationError
+            | JobDetailPageValidationError
+            | JobDetailPropertyValidationError
+            | JobSearchWithJobNumberFillingError
+        >;
+    }
+>() { }
+
+export function buildHelloWorkRawJobDetailHtmlExtractorLayer(config: HelloWorkScrapingConfig) {
+    return Layer.effect(
+        HelloWorkRawJobDetailHtmlExtractor,
+        Effect.gen(function* () {
+            yield* Effect.logInfo(
+                `building scraper: config=${JSON.stringify(config, null, 2)}`,
+            );
+            const browser = yield* launchBrowser(config.browserConfig);
+            const context = yield* createContext(browser);
+            const page = yield* createPage(context);
+            return HelloWorkRawJobDetailHtmlExtractor.of({
+                extractRawHtml: (jobNumber: JobNumber) =>
+                    Effect.gen(function* () {
+                        yield* Effect.logInfo("start extracting raw job detail HTML...");
+                        yield* Effect.logDebug("go to hello work seach page.");
+                        yield* goToJobSearchPage(page);
+                        const searchPage = yield* validateJobSearchPage(page);
+                        yield* Effect.logDebug(
+                            "fill jobNumber then go to hello work seach page.",
+                        );
+                        yield* searchNoThenGotoSingleJobListPage(searchPage, jobNumber);
+                        const jobListPage = yield* validateJobListPage(searchPage);
+                        yield* Effect.logDebug("now on job List page.");
+
+                        yield* goToSingleJobDetailPage(jobListPage);
+                        const jobDetailPage = yield* validateJobDetailPage(jobListPage);
+                        const rawHtml = yield* Effect.tryPromise({
+                            try: () => jobDetailPage.content(),
+                            catch: (error) => new ExtractJobDetailRawHtmlError({ message: `Failed to get page content: ${String(error)}` }),
+                        });
+                        return rawHtml;
+                    }),
+            });
+        }),
+    );
+}
+
+class ExtractJobDetailRawHtmlError extends Data.TaggedError("ExtractJobDetailRawHtmlError")<{
+    readonly message: string;
+}> { }

--- a/apps/headless-crawler/lib/rawJobDetailExtractor/context.ts
+++ b/apps/headless-crawler/lib/rawJobDetailExtractor/context.ts
@@ -1,9 +1,9 @@
 import type { JobNumber } from "@sho/models";
 import { Context, Data, Effect, Layer } from "effect";
 import {
-    createContext,
-    createPage,
-    launchBrowser,
+  createContext,
+  createPage,
+  launchBrowser,
 } from "../core/headless-browser";
 import type { NewPageError } from "../core/headless-browser/error";
 import type { HelloWorkScrapingConfig } from "../config/scraper";
@@ -12,84 +12,93 @@ import type { JobSearchPageValidationError } from "../core/page/JobSearch/valida
 import type { ListJobsError } from "../core/page/JobList/others/error";
 import type { AssertSingleJobListedError } from "../core/page/JobList/assertions/error";
 import type {
-    GoToJobSearchPageError,
-    SearchThenGotoFirstJobListPageError,
+  GoToJobSearchPageError,
+  SearchThenGotoFirstJobListPageError,
 } from "../core/page/JobSearch/navigations/error";
 import type { FromJobListToJobDetailPageError } from "../core/page/JobList/navigations/error";
 import type { JobSearchWithJobNumberFillingError } from "../core/page/JobSearch/form-fillings/error";
 import {
-    goToJobSearchPage,
-    searchNoThenGotoSingleJobListPage,
+  goToJobSearchPage,
+  searchNoThenGotoSingleJobListPage,
 } from "../core/page/JobSearch/navigations";
 import { goToSingleJobDetailPage } from "../core/page/JobList/navigations";
 import { validateJobDetailPage } from "../core/page/JobDetail/validators";
 import type {
-    JobDetailPageValidationError,
-    JobDetailPropertyValidationError,
+  JobDetailPageValidationError,
+  JobDetailPropertyValidationError,
 } from "../core/page/JobDetail/validators/error";
 import { validateJobSearchPage } from "../core/page/JobSearch/validators";
 import { validateJobListPage } from "../core/page/JobList/validators";
 
-export class HelloWorkRawJobDetailHtmlExtractor extends Context.Tag("HelloWorkRawJobDetailHtmlExtractor")<
+export class HelloWorkRawJobDetailHtmlExtractor extends Context.Tag(
+  "HelloWorkRawJobDetailHtmlExtractor",
+)<
+  HelloWorkRawJobDetailHtmlExtractor,
+  {
+    readonly extractRawHtml: (
+      jobNumber: JobNumber,
+    ) => Effect.Effect<
+      string,
+      | ListJobsError
+      | ExtractJobDetailRawHtmlError
+      | NewPageError
+      | AssertSingleJobListedError
+      | GoToJobSearchPageError
+      | SearchThenGotoFirstJobListPageError
+      | FromJobListToJobDetailPageError
+      | JobSearchPageValidationError
+      | JobListPageValidationError
+      | JobDetailPageValidationError
+      | JobDetailPropertyValidationError
+      | JobSearchWithJobNumberFillingError
+    >;
+  }
+>() {}
+
+export function buildHelloWorkRawJobDetailHtmlExtractorLayer(
+  config: HelloWorkScrapingConfig,
+) {
+  return Layer.effect(
     HelloWorkRawJobDetailHtmlExtractor,
-    {
-        readonly extractRawHtml: (
-            jobNumber: JobNumber,
-        ) => Effect.Effect<
-            string,
-            | ListJobsError
-            | ExtractJobDetailRawHtmlError
-            | NewPageError
-            | AssertSingleJobListedError
-            | GoToJobSearchPageError
-            | SearchThenGotoFirstJobListPageError
-            | FromJobListToJobDetailPageError
-            | JobSearchPageValidationError
-            | JobListPageValidationError
-            | JobDetailPageValidationError
-            | JobDetailPropertyValidationError
-            | JobSearchWithJobNumberFillingError
-        >;
-    }
->() { }
-
-export function buildHelloWorkRawJobDetailHtmlExtractorLayer(config: HelloWorkScrapingConfig) {
-    return Layer.effect(
-        HelloWorkRawJobDetailHtmlExtractor,
-        Effect.gen(function* () {
-            yield* Effect.logInfo(
-                `building scraper: config=${JSON.stringify(config, null, 2)}`,
+    Effect.gen(function* () {
+      yield* Effect.logInfo(
+        `building scraper: config=${JSON.stringify(config, null, 2)}`,
+      );
+      const browser = yield* launchBrowser(config.browserConfig);
+      const context = yield* createContext(browser);
+      const page = yield* createPage(context);
+      return HelloWorkRawJobDetailHtmlExtractor.of({
+        extractRawHtml: (jobNumber: JobNumber) =>
+          Effect.gen(function* () {
+            yield* Effect.logInfo("start extracting raw job detail HTML...");
+            yield* Effect.logDebug("go to hello work seach page.");
+            yield* goToJobSearchPage(page);
+            const searchPage = yield* validateJobSearchPage(page);
+            yield* Effect.logDebug(
+              "fill jobNumber then go to hello work seach page.",
             );
-            const browser = yield* launchBrowser(config.browserConfig);
-            const context = yield* createContext(browser);
-            const page = yield* createPage(context);
-            return HelloWorkRawJobDetailHtmlExtractor.of({
-                extractRawHtml: (jobNumber: JobNumber) =>
-                    Effect.gen(function* () {
-                        yield* Effect.logInfo("start extracting raw job detail HTML...");
-                        yield* Effect.logDebug("go to hello work seach page.");
-                        yield* goToJobSearchPage(page);
-                        const searchPage = yield* validateJobSearchPage(page);
-                        yield* Effect.logDebug(
-                            "fill jobNumber then go to hello work seach page.",
-                        );
-                        yield* searchNoThenGotoSingleJobListPage(searchPage, jobNumber);
-                        const jobListPage = yield* validateJobListPage(searchPage);
-                        yield* Effect.logDebug("now on job List page.");
+            yield* searchNoThenGotoSingleJobListPage(searchPage, jobNumber);
+            const jobListPage = yield* validateJobListPage(searchPage);
+            yield* Effect.logDebug("now on job List page.");
 
-                        yield* goToSingleJobDetailPage(jobListPage);
-                        const jobDetailPage = yield* validateJobDetailPage(jobListPage);
-                        const rawHtml = yield* Effect.tryPromise({
-                            try: () => jobDetailPage.content(),
-                            catch: (error) => new ExtractJobDetailRawHtmlError({ message: `Failed to get page content: ${String(error)}` }),
-                        });
-                        return rawHtml;
-                    }),
+            yield* goToSingleJobDetailPage(jobListPage);
+            const jobDetailPage = yield* validateJobDetailPage(jobListPage);
+            const rawHtml = yield* Effect.tryPromise({
+              try: () => jobDetailPage.content(),
+              catch: (error) =>
+                new ExtractJobDetailRawHtmlError({
+                  message: `Failed to get page content: ${String(error)}`,
+                }),
             });
-        }),
-    );
+            return rawHtml;
+          }),
+      });
+    }),
+  );
 }
 
-class ExtractJobDetailRawHtmlError extends Data.TaggedError("ExtractJobDetailRawHtmlError")<{
-    readonly message: string;
-}> { }
+class ExtractJobDetailRawHtmlError extends Data.TaggedError(
+  "ExtractJobDetailRawHtmlError",
+)<{
+  readonly message: string;
+}> {}

--- a/apps/headless-crawler/lib/rawJobDetailExtractor/index.ts
+++ b/apps/headless-crawler/lib/rawJobDetailExtractor/index.ts
@@ -1,0 +1,23 @@
+import { Effect, LogLevel, Logger } from "effect";
+import scraperConfig from "../config/scraper";
+import { validateJobNumber } from "../core/page/JobDetail/validators";
+import { buildHelloWorkRawJobDetailHtmlExtractorLayer, HelloWorkRawJobDetailHtmlExtractor } from "./context";
+export function extractJobDetailRawHtml(rawJobNumber: string) {
+    return Effect.gen(function* () {
+        const config = yield* Effect.promise(() => scraperConfig);
+        const layer = buildHelloWorkRawJobDetailHtmlExtractorLayer(config);
+        const program = Effect.gen(function* () {
+            const jobNumber = yield* validateJobNumber(rawJobNumber);
+            const extractor = yield* HelloWorkRawJobDetailHtmlExtractor;
+            const rawHtml = yield* extractor.extractRawHtml(jobNumber);
+            return rawHtml;
+        });
+        return yield* Effect.provide(program, layer)
+            .pipe(Effect.scoped)
+            .pipe(
+                Logger.withMinimumLogLevel(
+                    config.debugLog ? LogLevel.Debug : LogLevel.Info,
+                ),
+            );
+    });
+}

--- a/apps/headless-crawler/lib/rawJobDetailExtractor/index.ts
+++ b/apps/headless-crawler/lib/rawJobDetailExtractor/index.ts
@@ -1,23 +1,26 @@
 import { Effect, LogLevel, Logger } from "effect";
 import scraperConfig from "../config/scraper";
 import { validateJobNumber } from "../core/page/JobDetail/validators";
-import { buildHelloWorkRawJobDetailHtmlExtractorLayer, HelloWorkRawJobDetailHtmlExtractor } from "./context";
+import {
+  buildHelloWorkRawJobDetailHtmlExtractorLayer,
+  HelloWorkRawJobDetailHtmlExtractor,
+} from "./context";
 export function extractJobDetailRawHtml(rawJobNumber: string) {
-    return Effect.gen(function* () {
-        const config = yield* Effect.promise(() => scraperConfig);
-        const layer = buildHelloWorkRawJobDetailHtmlExtractorLayer(config);
-        const program = Effect.gen(function* () {
-            const jobNumber = yield* validateJobNumber(rawJobNumber);
-            const extractor = yield* HelloWorkRawJobDetailHtmlExtractor;
-            const rawHtml = yield* extractor.extractRawHtml(jobNumber);
-            return rawHtml;
-        });
-        return yield* Effect.provide(program, layer)
-            .pipe(Effect.scoped)
-            .pipe(
-                Logger.withMinimumLogLevel(
-                    config.debugLog ? LogLevel.Debug : LogLevel.Info,
-                ),
-            );
+  return Effect.gen(function* () {
+    const config = yield* Effect.promise(() => scraperConfig);
+    const layer = buildHelloWorkRawJobDetailHtmlExtractorLayer(config);
+    const program = Effect.gen(function* () {
+      const jobNumber = yield* validateJobNumber(rawJobNumber);
+      const extractor = yield* HelloWorkRawJobDetailHtmlExtractor;
+      const rawHtml = yield* extractor.extractRawHtml(jobNumber);
+      return rawHtml;
     });
+    return yield* Effect.provide(program, layer)
+      .pipe(Effect.scoped)
+      .pipe(
+        Logger.withMinimumLogLevel(
+          config.debugLog ? LogLevel.Debug : LogLevel.Info,
+        ),
+      );
+  });
 }


### PR DESCRIPTION
## 背景
求人番号から求人詳細HTMLを抽出する新たな処理が必要となったため、Lambda・SQS・関連処理を追加しました。

## このPRで解決すること
- 求人番号を受け取り、求人詳細HTMLを抽出するLambda（rawJobDetailExtracter）を新規追加
- 上記Lambda用のSQSキュー・Construct・Stack組み込みを追加
- 関連するヘルパー関数・ライブラリ・デプロイワークフローの修正

## 影響範囲
- apps/headless-crawler/functions/helpers/helper.ts
- apps/headless-crawler/functions/rawJobDetailExtracter/handler.ts
- apps/headless-crawler/infra/constructs/jobDetailRawHtmlExtractor.ts
- apps/headless-crawler/infra/stacks/headless-crawler-stack.ts
- apps/headless-crawler/lib/rawJobDetailExtractor/
- .github/workflows/deploy.yml

## 備考
- 既存機能への影響はありません。新規機能の追加です。
- 今後、求人詳細HTMLの活用や拡張も見据えた構成です。
- 現状、jobDetailExtractorがExtractとTransformの2つの責務を担っていますが、今後はExtractとTransformに分離する予定です。
- テストはtype-check（型チェック）のみです。