### PR TITLE
chore(headless-crawler): ブラウザ生成時のデバッグログを追加

### DIFF
--- a/apps/headless-crawler/lib/core/headless-browser/index.ts
+++ b/apps/headless-crawler/lib/core/headless-browser/index.ts
@@ -20,7 +20,11 @@ export function launchBrowser(options: LaunchOptions) {
       return { browser };
     }),
     ({ browser }) => Effect.promise(() => browser.close()),
-  ).pipe(Effect.map(({ browser }) => browser)).pipe(Effect.tap((b) => Effect.logDebug(`Browser launched: ${b.version()}`)));
+  )
+    .pipe(Effect.map(({ browser }) => browser))
+    .pipe(
+      Effect.tap((b) => Effect.logDebug(`Browser launched: ${b.version()}`)),
+    );
 }
 
 export function createContext(browser: Browser) {
@@ -34,7 +38,13 @@ export function createContext(browser: Browser) {
       return { context };
     }),
     ({ context }) => Effect.promise(() => context.close()),
-  ).pipe(Effect.map(({ context }) => context)).pipe(Effect.tap((c) => Effect.logDebug(`BrowserContext created: ${c.browser()?.version()}`)));
+  )
+    .pipe(Effect.map(({ context }) => context))
+    .pipe(
+      Effect.tap((c) =>
+        Effect.logDebug(`BrowserContext created: ${c.browser()?.version()}`),
+      ),
+    );
 }
 
 export function createPage(context: BrowserContext) {
@@ -50,5 +60,7 @@ export function createPage(context: BrowserContext) {
       return { page };
     }),
     ({ page }) => Effect.promise(() => page.close()),
-  ).pipe(Effect.map(({ page }) => page)).pipe(Effect.tap((p) => Effect.logDebug(`Page created: ${p.url()}`)));
+  )
+    .pipe(Effect.map(({ page }) => page))
+    .pipe(Effect.tap((p) => Effect.logDebug(`Page created: ${p.url()}`)));
 }

--- a/apps/headless-crawler/lib/core/headless-browser/index.ts
+++ b/apps/headless-crawler/lib/core/headless-browser/index.ts
@@ -20,7 +20,7 @@ export function launchBrowser(options: LaunchOptions) {
       return { browser };
     }),
     ({ browser }) => Effect.promise(() => browser.close()),
-  ).pipe(Effect.map(({ browser }) => browser));
+  ).pipe(Effect.map(({ browser }) => browser)).pipe(Effect.tap((b) => Effect.logDebug(`Browser launched: ${b.version()}`)));
 }
 
 export function createContext(browser: Browser) {
@@ -34,7 +34,7 @@ export function createContext(browser: Browser) {
       return { context };
     }),
     ({ context }) => Effect.promise(() => context.close()),
-  ).pipe(Effect.map(({ context }) => context));
+  ).pipe(Effect.map(({ context }) => context)).pipe(Effect.tap((c) => Effect.logDebug(`BrowserContext created: ${c.browser()?.version()}`)));
 }
 
 export function createPage(context: BrowserContext) {
@@ -50,5 +50,5 @@ export function createPage(context: BrowserContext) {
       return { page };
     }),
     ({ page }) => Effect.promise(() => page.close()),
-  ).pipe(Effect.map(({ page }) => page));
+  ).pipe(Effect.map(({ page }) => page)).pipe(Effect.tap((p) => Effect.logDebug(`Page created: ${p.url()}`)));
 }


### PR DESCRIPTION
## 背景
headless-crawlerのブラウザ・コンテキスト・ページ生成時の挙動をデバッグしやすくするため、ログ出力を強化しました。

## このPRで解決すること
- launchBrowser, createContext, createPage 各関数で、生成時にバージョンやURLなどのデバッグログを出力するように変更

## 影響範囲
- apps/headless-crawler/lib/core/headless-browser/index.ts

## 備考
- 機能追加・削除はありません。デバッグ用のログ出力強化のみです。
- 今後、headless-crawler全体でより詳細なログ機能を段階的に追加していく予定です。