### PR TITLE
chore(jobsearch-validator): バリデーション成功時にデバッグログを追加

### DIFF
--- a/apps/headless-crawler/lib/core/page/JobDetail/checkers/index.ts
+++ b/apps/headless-crawler/lib/core/page/JobDetail/checkers/index.ts
@@ -16,14 +16,16 @@ export function qualificationsElmExists(page: JobDetailPage) {
       new QualificationsElmNotFoundError({
         message: `unexpected error\n${String(e)}`,
       }),
-  }).pipe(Effect.tap((exists) => {
-    if (!exists) {
-      return Effect.logDebug(
-        "Warning: Qualifications element not found on the page."
-      );
-    }
-    return Effect.logDebug("Qualifications element found on the page.");
-  }));
+  }).pipe(
+    Effect.tap((exists) => {
+      if (!exists) {
+        return Effect.logDebug(
+          "Warning: Qualifications element not found on the page.",
+        );
+      }
+      return Effect.logDebug("Qualifications element found on the page.");
+    }),
+  );
 }
 
 export function homePageElmExists(page: JobDetailPage) {
@@ -37,10 +39,14 @@ export function homePageElmExists(page: JobDetailPage) {
       new HomePageElmNotFoundError({
         message: `unexpected error\n${String(e)}`,
       }),
-  }).pipe(Effect.tap((exists) => {
-    if (!exists) {
-      return Effect.logDebug("Warning: Home page element not found on the page.");
-    }
-    return Effect.logDebug("Home page element found on the page.");
-  }));
+  }).pipe(
+    Effect.tap((exists) => {
+      if (!exists) {
+        return Effect.logDebug(
+          "Warning: Home page element not found on the page.",
+        );
+      }
+      return Effect.logDebug("Home page element found on the page.");
+    }),
+  );
 }

--- a/apps/headless-crawler/lib/core/page/JobDetail/extractors/index.ts
+++ b/apps/headless-crawler/lib/core/page/JobDetail/extractors/index.ts
@@ -58,12 +58,14 @@ export function extractJobNumbers(jobOverviewList: JobOverViewList) {
           new ExtractJobNumbersError({
             message: `unexpected error. ${String(e)}`,
           }),
-      }).pipe(Effect.tap((raw) => {
-        if (raw === null) {
-          return Effect.logDebug("Warning: jobNumber textContent is null");
-        }
-        return Effect.logDebug(`rawJobNumber=${raw}`);
-      }));
+      }).pipe(
+        Effect.tap((raw) => {
+          if (raw === null) {
+            return Effect.logDebug("Warning: jobNumber textContent is null");
+          }
+          return Effect.logDebug(`rawJobNumber=${raw}`);
+        }),
+      );
       if (rawJobNumber === null) {
         return yield* Effect.fail(
           new ExtractJobNumbersError({ message: "jobNumber is null" }),
@@ -105,11 +107,11 @@ function extractCompanyName(page: JobDetailPage) {
       catch: (e) =>
         e instanceof v.ValiError
           ? new ExtractJobCompanyNameError({
-            message: e.message,
-          })
+              message: e.message,
+            })
           : new ExtractJobCompanyNameError({
-            message: `unexpected error.\n${String(e)}`,
-          }),
+              message: `unexpected error.\n${String(e)}`,
+            }),
     });
     yield* Effect.logDebug(`rawCompanyName=${rawCompanyName}`);
     const companyName = yield* validateCompanyName(rawCompanyName);

--- a/apps/headless-crawler/lib/core/page/JobDetail/validators/index.ts
+++ b/apps/headless-crawler/lib/core/page/JobDetail/validators/index.ts
@@ -65,19 +65,20 @@ export function validateCompanyName(val: unknown) {
     if (!result.success) {
       return yield* Effect.fail(
         new CompanyNameValidationError({ message: result.issues.join("\n") }),
-      ).pipe(Effect.tap(() => {
-        return Effect.logDebug(
-          `failed to validate companyName. received=${JSON.stringify(
-            val,
-            null,
-            2,
-          )}`,
-        );
-      }));
+      ).pipe(
+        Effect.tap(() => {
+          return Effect.logDebug(
+            `failed to validate companyName. received=${JSON.stringify(
+              val,
+              null,
+              2,
+            )}`,
+          );
+        }),
+      );
     }
     return yield* Effect.succeed(result.output);
   });
-
 }
 
 export function validateReceivedDate(val: unknown) {
@@ -86,19 +87,20 @@ export function validateReceivedDate(val: unknown) {
     if (!result.success) {
       return yield* Effect.fail(
         new ReceivedDateValidationError({ message: result.issues.join("\n") }),
-      ).pipe(Effect.tap(() => {
-        Effect.logDebug(
-          `failed to validate receivedDate. received=${JSON.stringify(
-            val,
-            null,
-            2,
-          )}`,
-        );
-      }));
+      ).pipe(
+        Effect.tap(() => {
+          Effect.logDebug(
+            `failed to validate receivedDate. received=${JSON.stringify(
+              val,
+              null,
+              2,
+            )}`,
+          );
+        }),
+      );
     }
     return yield* Effect.succeed(result.output);
   });
-
 }
 export function validateExpiryDate(val: unknown) {
   return Effect.gen(function* () {
@@ -106,15 +108,17 @@ export function validateExpiryDate(val: unknown) {
     if (!result.success) {
       return yield* Effect.fail(
         new ExpiryDateValidationError({ message: result.issues.join("\n") }),
-      ).pipe(Effect.tap(() => {
-        Effect.logDebug(
-          `failed to validate expiryDate. received=${JSON.stringify(
-            val,
-            null,
-            2,
-          )}`,
-        );
-      }));
+      ).pipe(
+        Effect.tap(() => {
+          Effect.logDebug(
+            `failed to validate expiryDate. received=${JSON.stringify(
+              val,
+              null,
+              2,
+            )}`,
+          );
+        }),
+      );
     }
     return yield* Effect.succeed(result.output);
   });
@@ -125,15 +129,17 @@ export function validateHomePage(val: unknown) {
     if (!result.success) {
       return yield* Effect.fail(
         new HomePageValidationError({ message: result.issues.join("\n") }),
-      ).pipe(Effect.tap(() => {
-        Effect.logDebug(
-          `failed to validate homePage. received=${JSON.stringify(
-            val,
-            null,
-            2,
-          )}`,
-        );
-      }));
+      ).pipe(
+        Effect.tap(() => {
+          Effect.logDebug(
+            `failed to validate homePage. received=${JSON.stringify(
+              val,
+              null,
+              2,
+            )}`,
+          );
+        }),
+      );
     }
     return yield* Effect.succeed(result.output);
   });
@@ -151,15 +157,17 @@ export function validateOccupation(val: unknown) {
       );
       return yield* Effect.fail(
         new OccupationValidationError({ message: result.issues.join("\n") }),
-      ).pipe(Effect.tap(() => {
-        Effect.logDebug(
-          `failed to validate occupation. received=${JSON.stringify(
-            val,
-            null,
-            2,
-          )}`,
-        );
-      }));
+      ).pipe(
+        Effect.tap(() => {
+          Effect.logDebug(
+            `failed to validate occupation. received=${JSON.stringify(
+              val,
+              null,
+              2,
+            )}`,
+          );
+        }),
+      );
     }
     yield* Effect.logDebug(
       `succeeded to validate occupation. val=${JSON.stringify(result.output, null, 2)}`,
@@ -175,8 +183,8 @@ export function validateEmploymentType(val: unknown) {
       e instanceof v.ValiError
         ? new EmploymentTypeValidationError({ message: e.message })
         : new EmploymentTypeValidationError({
-          message: `unexpected error.\n${String(e)}`,
-        }),
+            message: `unexpected error.\n${String(e)}`,
+          }),
   });
 }
 
@@ -191,11 +199,15 @@ export function validateWage(val: unknown) {
         e instanceof v.ValiError
           ? new WageValidationError({ message: e.message })
           : new WageValidationError({
-            message: `unexpected error.\n${String(e)}`,
-          }),
-    }).pipe(Effect.tap((wage) => {
-      return Effect.logDebug(`succeeded to validate wage. val=${JSON.stringify(wage, null, 2)}`);
-    }));
+              message: `unexpected error.\n${String(e)}`,
+            }),
+    }).pipe(
+      Effect.tap((wage) => {
+        return Effect.logDebug(
+          `succeeded to validate wage. val=${JSON.stringify(wage, null, 2)}`,
+        );
+      }),
+    );
   });
 }
 
@@ -206,11 +218,15 @@ export function validateWorkingHours(val: unknown) {
       e instanceof v.ValiError
         ? new WorkingHoursValidationError({ message: e.message })
         : new WorkingHoursValidationError({
-          message: `unexpected error.\n${String(e)}`,
-        }),
-  }).pipe(Effect.tap((workingHours) => {
-    return Effect.logDebug(`succeeded to validate workingHours. val=${JSON.stringify(workingHours, null, 2)}`);
-  }));
+            message: `unexpected error.\n${String(e)}`,
+          }),
+  }).pipe(
+    Effect.tap((workingHours) => {
+      return Effect.logDebug(
+        `succeeded to validate workingHours. val=${JSON.stringify(workingHours, null, 2)}`,
+      );
+    }),
+  );
 }
 export function validateEmployeeCount(val: unknown) {
   return Effect.try({
@@ -219,11 +235,15 @@ export function validateEmployeeCount(val: unknown) {
       e instanceof v.ValiError
         ? new EmployeeCountValidationError({ message: e.message })
         : new EmployeeCountValidationError({
-          message: `unexpected error.\n${String(e)}`,
-        }),
-  }).pipe(Effect.tap((employeeCount) => {
-    return Effect.logDebug(`succeeded to validate employeeCount. val=${JSON.stringify(employeeCount, null, 2)}`);
-  }));
+            message: `unexpected error.\n${String(e)}`,
+          }),
+  }).pipe(
+    Effect.tap((employeeCount) => {
+      return Effect.logDebug(
+        `succeeded to validate employeeCount. val=${JSON.stringify(employeeCount, null, 2)}`,
+      );
+    }),
+  );
 }
 
 export function validateWorkPlace(val: unknown) {
@@ -233,11 +253,15 @@ export function validateWorkPlace(val: unknown) {
       e instanceof v.ValiError
         ? new WorkPlaceValidationError({ message: e.message })
         : new WorkPlaceValidationError({
-          message: `unexpected error. \n${String(e)}`,
-        }),
-  }).pipe(Effect.tap((workPlace) => {
-    return Effect.logDebug(`succeeded to validate workPlace. val=${JSON.stringify(workPlace, null, 2)}`);
-  }));
+            message: `unexpected error. \n${String(e)}`,
+          }),
+  }).pipe(
+    Effect.tap((workPlace) => {
+      return Effect.logDebug(
+        `succeeded to validate workPlace. val=${JSON.stringify(workPlace, null, 2)}`,
+      );
+    }),
+  );
 }
 
 export function validateJobDescription(val: unknown) {
@@ -247,11 +271,15 @@ export function validateJobDescription(val: unknown) {
       e instanceof v.ValiError
         ? new JobDescriptionValidationError({ message: e.message })
         : new JobDescriptionValidationError({
-          message: `unexpected error.\n${String}`,
-        }),
-  }).pipe(Effect.tap((jobDescription) => {
-    return Effect.logDebug(`succeeded to validate jobDescription. val=${JSON.stringify(jobDescription, null, 2)}`);
-  }));
+            message: `unexpected error.\n${String}`,
+          }),
+  }).pipe(
+    Effect.tap((jobDescription) => {
+      return Effect.logDebug(
+        `succeeded to validate jobDescription. val=${JSON.stringify(jobDescription, null, 2)}`,
+      );
+    }),
+  );
 }
 
 export function validateQualification(
@@ -264,15 +292,17 @@ export function validateQualification(
   if (!result.success) {
     return Effect.fail(
       new QualificationValidationError({ message: result.issues.join("\n") }),
-    ).pipe(Effect.tap(() => {
-      Effect.logDebug(
-        `failed to validate qualification. received=${JSON.stringify(
-          val,
-          null,
-          2,
-        )}`,
-      );
-    }));
+    ).pipe(
+      Effect.tap(() => {
+        Effect.logDebug(
+          `failed to validate qualification. received=${JSON.stringify(
+            val,
+            null,
+            2,
+          )}`,
+        );
+      }),
+    );
   }
   return Effect.succeed(result.output);
 }
@@ -289,9 +319,11 @@ export function validateJobDetailPage(
         new JobDetailPageValidationError({
           message: `unexpected error.\n${String(e)}`,
         }),
-    }).pipe(Effect.tap((jobTitle) => {
-      return Effect.logDebug(`extracted job title: ${jobTitle}`);
-    }));
+    }).pipe(
+      Effect.tap((jobTitle) => {
+        return Effect.logDebug(`extracted job title: ${jobTitle}`);
+      }),
+    );
     if (jobTitle !== "求人情報")
       throw new JobDetailPageValidationError({
         message: `textContent of div.page_title should be 求人情報 but got: "${jobTitle}"`,

--- a/apps/headless-crawler/lib/core/page/JobList/assertions/index.ts
+++ b/apps/headless-crawler/lib/core/page/JobList/assertions/index.ts
@@ -8,11 +8,12 @@ export function assertSingleJobListed(page: JobListPage) {
     const jobOverViewList = yield* listJobOverviewElem(page);
     if (jobOverViewList.length !== 1)
       yield* Effect.logDebug(
-        `failed to assert single job listed. job count=${jobOverViewList.length}`
+        `failed to assert single job listed. job count=${jobOverViewList.length}`,
       );
     return yield* Effect.fail(
       new AssertSingleJobListedError({
         message: `job list count should be 1 but ${jobOverViewList.length}`,
-      }));
+      }),
+    );
   });
 }

--- a/apps/headless-crawler/lib/core/page/JobList/navigations/index.ts
+++ b/apps/headless-crawler/lib/core/page/JobList/navigations/index.ts
@@ -19,9 +19,13 @@ export function goToSingleJobDetailPage(page: JobListPage) {
         new FromJobListToJobDetailPageError({
           message: `unexpected error.\n${String(e)}`,
         }),
-    }).pipe(Effect.tap(() => {
-      return Effect.logDebug("navigated to job detail page from job list page.");
-    }));
+    }).pipe(
+      Effect.tap(() => {
+        return Effect.logDebug(
+          "navigated to job detail page from job list page.",
+        );
+      }),
+    );
     return page;
   });
 }
@@ -35,7 +39,9 @@ export function goToNextJobListPage(page: JobListPage) {
     },
     catch: (e) =>
       new NextJobListPageError({ message: `unexpected error.\n${String(e)}` }),
-  }).pipe(Effect.tap(() => {
-    return Effect.logDebug("navigated to next job list page.");
-  }));
+  }).pipe(
+    Effect.tap(() => {
+      return Effect.logDebug("navigated to next job list page.");
+    }),
+  );
 }

--- a/apps/headless-crawler/lib/core/page/JobList/others/index.ts
+++ b/apps/headless-crawler/lib/core/page/JobList/others/index.ts
@@ -9,15 +9,21 @@ export function listJobOverviewElem(
     try: () => jobListPage.locator("table.kyujin.mt1.noborder").all(),
     catch: (e) =>
       new ListJobsError({ message: `unexpected error.\n${String(e)}` }),
-  }).pipe(
-    Effect.flatMap((tables) =>
-      tables.length === 0
-        ? Effect.fail(new ListJobsError({ message: "jobOverList is empty." }))
-        : Effect.succeed(tables as JobOverViewList),
-    ),
-  ).pipe(Effect.tap((jobOverViewList) => {
-    return Effect.logDebug(`succeeded to list job overview elements. count=${jobOverViewList.length}`);
-  }));
+  })
+    .pipe(
+      Effect.flatMap((tables) =>
+        tables.length === 0
+          ? Effect.fail(new ListJobsError({ message: "jobOverList is empty." }))
+          : Effect.succeed(tables as JobOverViewList),
+      ),
+    )
+    .pipe(
+      Effect.tap((jobOverViewList) => {
+        return Effect.logDebug(
+          `succeeded to list job overview elements. count=${jobOverViewList.length}`,
+        );
+      }),
+    );
 }
 
 export function isNextPageEnabled(page: JobListPage) {
@@ -32,7 +38,9 @@ export function isNextPageEnabled(page: JobListPage) {
         message: `unexpected error. ${String(e)}`,
       });
     },
-  }).pipe(Effect.tap((enabled) => {
-    return Effect.logDebug(`is next page enabled: ${enabled}`);
-  }));
+  }).pipe(
+    Effect.tap((enabled) => {
+      return Effect.logDebug(`is next page enabled: ${enabled}`);
+    }),
+  );
 }

--- a/apps/headless-crawler/lib/core/page/JobList/validators/index.ts
+++ b/apps/headless-crawler/lib/core/page/JobList/validators/index.ts
@@ -12,15 +12,19 @@ export function validateJobListPage(page: Page) {
       new JobListPageValidationError({
         message: `unexpected error. ${String(e)}`,
       }),
-  }).pipe(
-    Effect.flatMap((pageCount) =>
-      pageCount === 0
-        ? Effect.fail(
-          new JobListPageValidationError({ message: "job list is empty" }),
-        )
-        : Effect.succeed(page as JobListPage),
-    ),
-  ).pipe(Effect.tap((_) => {
-    return Effect.logDebug("succeeded to validate job list page.");
-  }));
+  })
+    .pipe(
+      Effect.flatMap((pageCount) =>
+        pageCount === 0
+          ? Effect.fail(
+              new JobListPageValidationError({ message: "job list is empty" }),
+            )
+          : Effect.succeed(page as JobListPage),
+      ),
+    )
+    .pipe(
+      Effect.tap((_) => {
+        return Effect.logDebug("succeeded to validate job list page.");
+      }),
+    );
 }

--- a/apps/headless-crawler/lib/core/page/JobSearch/form-fillings/index.ts
+++ b/apps/headless-crawler/lib/core/page/JobSearch/form-fillings/index.ts
@@ -33,9 +33,13 @@ function fillWorkType(page: JobSearchPage, employmentType: EmploymentType) {
         new FillWorkTypeError({
           message: `Error: invalid employmentType: ${employmentType}`,
         }),
-    }).pipe(Effect.tap(() => {
-      return Effect.logDebug(`filled work type field. employmentType=${employmentType}`);
-    }));
+    }).pipe(
+      Effect.tap(() => {
+        return Effect.logDebug(
+          `filled work type field. employmentType=${employmentType}`,
+        );
+      }),
+    );
   });
 }
 
@@ -57,9 +61,13 @@ function fillPrefectureField(
         new FillPrefectureFieldError({
           message: `Error: workLocation=${workLocation} ${String(e)}`,
         }),
-    }).pipe(Effect.tap(() => {
-      return Effect.logDebug(`filled prefecture field. prefecture=${prefecture}`);
-    }));
+    }).pipe(
+      Effect.tap(() => {
+        return Effect.logDebug(
+          `filled prefecture field. prefecture=${prefecture}`,
+        );
+      }),
+    );
   });
 }
 
@@ -87,9 +95,11 @@ function fillOccupationField(page: JobSearchPage, label: EngineeringLabel) {
         new FillOccupationFieldError({
           message: `unexpected Error. label=${label}\n${String(e)}`,
         }),
-    }).pipe(Effect.tap(() => {
-      return Effect.logDebug(`filled occupation field. label=${label}`);
-    }));
+    }).pipe(
+      Effect.tap(() => {
+        return Effect.logDebug(`filled occupation field. label=${label}`);
+      }),
+    );
   });
 }
 
@@ -108,9 +118,13 @@ export function fillJobCriteriaField(
     if (searchPeriod) {
       yield* fillJobPeriod(page, searchPeriod);
     }
-  }).pipe(Effect.tap(() => {
-    return Effect.logDebug(`filled job criteria fields. criteria=${JSON.stringify(jobSearchCriteria, null, 2)}`);
-  }));
+  }).pipe(
+    Effect.tap(() => {
+      return Effect.logDebug(
+        `filled job criteria fields. criteria=${JSON.stringify(jobSearchCriteria, null, 2)}`,
+      );
+    }),
+  );
 }
 
 function engineeringLabelToSelector(
@@ -173,9 +187,11 @@ export function fillJobNumber(page: JobSearchPage, jobNumber: JobNumber) {
       new FillJobNumberError({
         message: `unexpected error.\njobNumber=${jobNumber}\n${String(e)}`,
       }),
-  }).pipe(Effect.tap(() => {
-    return Effect.logDebug(`filled job number field. jobNumber=${jobNumber}`);
-  }));
+  }).pipe(
+    Effect.tap(() => {
+      return Effect.logDebug(`filled job number field. jobNumber=${jobNumber}`);
+    }),
+  );
 }
 
 export function fillJobPeriod(page: JobSearchPage, searchPeriod: SearchPeriod) {
@@ -198,7 +214,11 @@ export function fillJobPeriod(page: JobSearchPage, searchPeriod: SearchPeriod) {
             message: `Error: searchPeriod=${searchPeriod} ${String(e)}`,
           }),
       }));
-  }).pipe(Effect.tap(() => {
-    return Effect.logDebug(`filled job period field. searchPeriod=${searchPeriod}`);
-  }));
+  }).pipe(
+    Effect.tap(() => {
+      return Effect.logDebug(
+        `filled job period field. searchPeriod=${searchPeriod}`,
+      );
+    }),
+  );
 }

--- a/apps/headless-crawler/lib/core/page/JobSearch/navigations/index.ts
+++ b/apps/headless-crawler/lib/core/page/JobSearch/navigations/index.ts
@@ -20,9 +20,11 @@ export function goToJobSearchPage(page: Page) {
       new GoToJobSearchPageError({
         message: `unexpected error.\n${String(e)}`,
       }),
-  }).pipe(Effect.tap(() => {
-    return Effect.logDebug("navigated to job search page.");
-  }));
+  }).pipe(
+    Effect.tap(() => {
+      return Effect.logDebug("navigated to job search page.");
+    }),
+  );
 }
 
 export function searchThenGotoJobListPage(
@@ -44,9 +46,13 @@ export function searchThenGotoJobListPage(
         new SearchThenGotoJobListPageError({
           message: `unexpected error.\n${String(e)}`,
         }),
-    }).pipe(Effect.tap(() => {
-      return Effect.logDebug("navigated to job list page from job search page.");
-    }));
+    }).pipe(
+      Effect.tap(() => {
+        return Effect.logDebug(
+          "navigated to job list page from job search page.",
+        );
+      }),
+    );
   });
 }
 export function searchNoThenGotoSingleJobListPage(
@@ -67,9 +73,13 @@ export function searchNoThenGotoSingleJobListPage(
         new SearchThenGotoFirstJobListPageError({
           message: `unexpected error.\n${String(e)}`,
         }),
-    }).pipe(Effect.tap(() => {
-      return Effect.logDebug("navigated to job list page from job search page.");
-    }));
+    }).pipe(
+      Effect.tap(() => {
+        return Effect.logDebug(
+          "navigated to job list page from job search page.",
+        );
+      }),
+    );
   });
 }
 

--- a/apps/headless-crawler/lib/core/page/JobSearch/validators/index.ts
+++ b/apps/headless-crawler/lib/core/page/JobSearch/validators/index.ts
@@ -20,9 +20,11 @@ export function validateJobSearchPage(page: Page) {
         new JobSearchPageValidationError({
           message: `unexpected error.\n${String(e)}`,
         }),
-    }).pipe(Effect.tap(() => {
-      return Effect.logDebug("succeeded to validate job search page.");
-    }));
+    }).pipe(
+      Effect.tap(() => {
+        return Effect.logDebug("succeeded to validate job search page.");
+      }),
+    );
     return jobSearchPage;
   });
 }


### PR DESCRIPTION
## 概要

JobSearchページのバリデーション成功時に`Effect.logDebug`でデバッグログを出力するようにしました。これにより、バリデーション処理のトレース性が向上します。

## 変更内容

- `validateJobSearchPage`関数でバリデーション成功時にデバッグログを追加

## 背景・目的

バリデーション処理の成否をログで追跡できるようにし、デバッグや運用時のトラブルシュートを容易にするためです。

## 今後の展望

今後も他のバリデーション・チェック処理にも同様のログ出力を追加し、全体的な可観測性を高めていく予定です。