### PR TITLE
fix(headless-crawler): ジョブリストのassertion条件を修正

### DIFF
--- a/apps/headless-crawler/lib/core/page/JobList/assertions/index.ts
+++ b/apps/headless-crawler/lib/core/page/JobList/assertions/index.ts
@@ -6,7 +6,7 @@ import { AssertSingleJobListedError } from "./error";
 export function assertSingleJobListed(page: JobListPage) {
   return Effect.gen(function* () {
     const jobOverViewList = yield* listJobOverviewElem(page);
-    if (jobOverViewList.length !== 1)
+    if (jobOverViewList.length !== 1) {
       yield* Effect.logDebug(
         `failed to assert single job listed. job count=${jobOverViewList.length}`,
       );
@@ -15,5 +15,6 @@ export function assertSingleJobListed(page: JobListPage) {
         message: `job list count should be 1 but ${jobOverViewList.length}`,
       }),
     );
+    }
   });
 }


### PR DESCRIPTION
## 概要

ジョブリストのassertion条件を修正し、ジョブ数が1件でない場合のみエラーとなるようにしました。

## 変更内容

- `assertSingleJobListed` のif文を修正し、ジョブ数が1件でない場合のみエラー・デバッグログを出力するように変更

## 背景・目的

従来の実装では、すべてのケースでエラーとなっていたため、正常なケースでもエラーが発生していました。  
本修正により、ジョブ数が1件でない場合のみ正しくエラーとなるようになり、意図したバリデーションが行われます。

## 補足

今後もバリデーションロジックの正確性・可観測性向上に努めます。