### PR TITLE
chore(headless-crawler): scrape開始時のログにjobNumberを含める

### DIFF
--- a/apps/headless-crawler/lib/scraper/context.ts
+++ b/apps/headless-crawler/lib/scraper/context.ts
@@ -75,7 +75,7 @@ export function buildHelloWorkScrapingLayer(config: HelloWorkScrapingConfig) {
       return HelloWorkScraper.of({
         scrapeJobData: (jobNumber: JobNumber) =>
           Effect.gen(function* () {
-            yield* Effect.logInfo("start scrapling...");
+            yield* Effect.logInfo(`start scrapling... jobNumber=${jobNumber}`);
             yield* Effect.logDebug("go to hello work seach page.");
             yield* goToJobSearchPage(page);
             const searchPage = yield* validateJobSearchPage(page);


### PR DESCRIPTION
## 概要

`scrapeJobData` 実行時のログに `jobNumber` を含めるようにし、どの求人番号のスクレイピング処理かが一目で分かるようにしました。

## 変更内容

- `scrapeJobData` 開始時の `Effect.logInfo` に `jobNumber` を追加

## 背景・目的

複数ジョブのスクレイピング時に、どのジョブ番号の処理かをログから容易に特定できるようにし、デバッグや運用時のトレース性を向上させるためです。

## 補足

今後もログの粒度や内容を見直し、可観測性の向上に努めます。