### PR TITLE
WIP: chore(headless-crawler): insertJobSuccessResponseのバリデーション処理を削除

### DIFF
--- a/apps/headless-crawler/functions/extractTransformAndSaveJobDetailHandler/helper.ts
+++ b/apps/headless-crawler/functions/extractTransformAndSaveJobDetailHandler/helper.ts
@@ -184,8 +184,6 @@ export function buildJobStoreClient() {
           yield* Effect.logDebug(
             `response data. ${JSON.stringify(data, null, 2)}`,
           );
-          const validated = yield* validateInsertJobSuccessResponse(data);
-          return validated;
         }),
     };
   });


### PR DESCRIPTION
- buildJobStoreClient内でのvalidateInsertJobSuccessResponse呼び出しを削除
- レスポンスデータのログ出力のみを残すように変更