### PR TITLE
WIP: chore(root): pre-commitのpinact実行をnixからbrewに切り替え

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,7 @@
 pnpm --filter job-store-api run copy-schema
 git add apps/job-store-api/src/db/schema.ts
 pnpm exec lint-staged
-nix-shell -p pinact --run "pinact run"
+pinact run
 git add $(git diff --name-only -- 'github/workflows/*')
 git add .github/workflows/* 
 


### PR DESCRIPTION
## 概要

pre-commitフック内でのpinact実行方法を、nix-shell経由からbrewインストール版に一時的に切り替えました。

## 変更内容

- `.husky/pre-commit` の `pinact` 実行コマンドを `nix-shell -p pinact --run "pinact run"` から `pinact run` に変更

## 背景

nixのチャネルや設定変更により、`nix-shell -p pinact` でpinactが実行できなくなる問題が発生していました。  
brewでpinactをインストールすることで一時的に対応しています。  
**これは一時的な対処であり、nixでpinactが再び利用可能になった際は元のnix-shell経由の実行に戻す予定です。**

## 影響範囲

- pre-commitフックの実行環境
- 今後はbrewでpinactがインストールされていることが前提となります

## テスト

- brewでpinactをインストールした環境でpre-commitが正常に動作することを確認

## 備考

- 他の開発者も `brew install pinact` を実行してください
- 必要に応じてREADME等にセットアップ手順を追記してください
- 将来的にnixでpinactが再び利用可能になった場合は、nix-shell経由の実行に戻す予定です