### PR TITLE
fix(headless-crawler): rawJobDetailExtractorをjobDetailExtractorにリネームし…

### DIFF
--- a/apps/headless-crawler/infra/constructs/jobDetailRawHtmlExtractor.ts
+++ b/apps/headless-crawler/infra/constructs/jobDetailRawHtmlExtractor.ts
@@ -17,7 +17,7 @@ export class JobDetailRawHtmlExtractorConstruct extends Construct {
   ) {
     super(scope, id);
     this.extractor = new NodejsFunction(this, id, {
-      entry: "functions/rawJobDetailExtracter/handler.ts",
+      entry: "functions/extractJobDetailHandler/handler.ts",
       handler: "handler",
       runtime: lambda.Runtime.NODEJS_22_X,
       memorySize: 1024,


### PR DESCRIPTION
## 概要

`rawJobDetailExtractor` 関連のディレクトリ・ファイル名を `jobDetailExtractor` にリネームし、CDKのLambdaエントリポイントも新パスに修正しました。  
これにより、デプロイ時のエラーを解消し、命名の一貫性・可読性も向上しています。

## 変更内容

- ディレクトリ・ファイル名を `rawJobDetailExtractor` → `jobDetailExtractor` に統一
- CDK（constructs/jobDetailExtractor.ts）のLambdaエントリポイントを新パスに修正
- 関連するimportパスや参照もすべて新名称に変更

## 背景

リネーム漏れにより、CDKデプロイ時にエントリポイントが見つからずエラーとなっていました。  
本PRで命名の統一とともに、デプロイエラーを解消します。

## 影響範囲

- Lambda関数、CDKスタック、ライブラリのimportパス
- デプロイ時の挙動

## テスト

- type-check、デプロイ、既存の動作確認を実施予定

## 備考

- 今後も命名・構成の一貫性を意識してリファクタリングを進めます