### PR TITLE
WIP: docs: READMEファイルの追加と更新

### DIFF
--- a/PORTFOLIO_DETAIL.md
+++ b/PORTFOLIO_DETAIL.md
@@ -467,10 +467,10 @@ const result = safeTry(async function* () {
 ### 1. @sho/models
 
 - **役割**: 全パッケージ共通の型定義・スキーマ管理（Source of Truth）
-- **主な技術**: TypeScript, Zod, Drizzle ORM, tsup
+- **主な技術**: TypeScript, Valibot, Drizzle ORM, tsdown
 - **設計ポイント**:
   - 型の一元管理でパッケージ間の整合性担保
-  - Zodによるランタイムバリデーション
+  - Valibotによるランタイムバリデーション
   - Drizzle ORMによるDB型定義
   - フロントエンド〜バックエンド〜DBまでの型の一貫性
 
@@ -479,7 +479,7 @@ const result = safeTry(async function* () {
 - **役割**: ハローワークサイトのクローリング・スクレイピング
 - **主な技術**: 
   - Playwright (v1.53.1) - ブラウザ自動化
-  - AWS CDK (v2.1025.0) - インフラ管理
+  - AWS CDK (v2.1029.2 / v2.216.0) - インフラ管理
   - Effect (v3.16.5) - 関数型プログラミング（neverthrowに移行予定）
   - @sparticuz/chromium (v138.0.0) - Lambda用Chromium
   - @aws-sdk/client-sqs (v3.840.0) - SQS連携
@@ -501,8 +501,8 @@ const result = safeTry(async function* () {
   - Drizzle ORM (v0.44.2) - データベースORM
   - Hono (v4.8.3) - Webフレームワーク
   - D1 (SQLite) - データベース
-  - Chanfana (v2.8.1) - OpenAPI生成
-  - Vitest (v3.2.0) - テスト
+  - hono-openapi (v1.0.8) - OpenAPI生成
+  - Vitest (v3.2.4) - テスト
   - neverthrow (v8.2.0) - エラーハンドリング
   - Wrangler (v4.26.1) - デプロイメントツール
   - @hono/zod-openapi (v1.0.2) - OpenAPI統合
@@ -515,9 +515,9 @@ const result = safeTry(async function* () {
   - neverthrowによる型安全なエラーハンドリング
   - ルートパスから自動的にドキュメントページへリダイレクト
   - 主要エンドポイント:
-    - `POST /api/v1/job` - 求人情報登録
+    - `POST /api/v1/jobs/` - 求人情報登録
     - `GET /api/v1/jobs/:jobNumber` - 求人詳細取得
-    - `GET /api/v1/jobs` - 求人一覧取得（高度なフィルタリング対応）
+    - `GET /api/v1/jobs/` - 求人一覧取得（高度なフィルタリング対応）
     - `GET /api/v1/jobs/continue` - 継続ページネーション（JWTトークンベース）
 
 ### 4. hello-work-job-searcher
@@ -525,7 +525,7 @@ const result = safeTry(async function* () {
 - **役割**: ユーザーインターフェース
 - **主な技術**:
   - React (v19.1.1)
-  - Next.js (v15.4.7) - App Router
+  - Next.js (v15.5.3) - App Router
   - TypeScript (v5)
   - Turbopack - 開発時高速化
   - TanStack React Virtual (v3.13.12) - 仮想化による無限スクロール

--- a/README.md
+++ b/README.md
@@ -110,24 +110,23 @@ graph TD
 - **目的**: 共通の型定義とスキーマ（Source of Truth）
 - **技術**:
   - Valibot (v1.1.0) - スキーマバリデーション
-  - Zod (v4.1.5) - 追加スキーマバリデーション
   - Drizzle ORM (v0.44.2) - データベーススキーマ
   - TypeScript (v5.8.3) - 型定義
   - tsdown (v0.15.3) - ビルドツール
-  - Playwright (v1.53.1) - テスト用ブラウザ自動化
+  - Playwright (v1.53.1) - テスト用ブラウザ自動化（devDependency）
 
 ##### `apps/headless-crawler`
 
 - **目的**: ハローワークサイトのクローリング・スクレイピング
 - **技術**: 
   - Playwright (v1.53.1) - ブラウザ自動化
-  - AWS CDK (v2.1029.0) - インフラ管理
+  - AWS CDK (v2.1029.2 / v2.216.0) - インフラ管理
   - Effect (v3.16.5) - 関数型プログラミング（**今後neverthrowに移行予定**）
   - @sparticuz/chromium (v138.0.0) - Lambda用Chromium
   - @aws-sdk/client-sqs (v3.840.0) - SQS連携
   - esbuild (v0.25.5) - ビルドツール
   - AWS Lambda + SQS - 実行環境
-  - Valibot (v1.1.0) + Zod (v4.1.5) - スキーマバリデーション
+  - Valibot (v1.1.0) - スキーマバリデーション
 - **機能**:
   - 求人検索条件に基づく求人一覧取得
   - 個別求人詳細情報のスクレイピング
@@ -146,7 +145,7 @@ graph TD
   - Vitest (v3.2.4) - テスト
   - Valibot (v1.1.0) - バリデーション
   - neverthrow (v8.2.0) - エラーハンドリング
-  - Wrangler (v4.35.0) - デプロイメントツール
+  - Wrangler (v4.38.0) - デプロイメントツール
   - tsdown (v0.15.3) - ビルドツール
   - @hono/valibot-validator (v0.5.3) - Valibotバリデーション統合
   - @hono/swagger-ui (v0.5.2) - Swagger UI統合
@@ -159,22 +158,23 @@ graph TD
   - OpenAPI仕様書自動生成 (`/api/v1/docs`, `/docs`, `/openapi`)
   - ルートパスから自動的にドキュメントページへリダイレクト
   - 主要エンドポイント:
-    - `POST /api/v1/job` - 求人情報登録
+    - `POST /api/v1/jobs/` - 求人情報登録
     - `GET /api/v1/jobs/:jobNumber` - 求人詳細取得
-    - `GET /api/v1/jobs` - 求人一覧取得（高度なフィルタリング対応）
+    - `GET /api/v1/jobs/` - 求人一覧取得（高度なフィルタリング対応）
       - `companyName` - 会社名フィルタ（URLエンコード対応）
       - `jobDescription` - 職務内容キーワード検索
       - `jobDescriptionExclude` - 除外キーワード検索
       - `employeeCountGt` / `employeeCountLt` - 従業員数範囲フィルタ
       - `onlyNotExpired` - 期限切れ求人の除外
+      - `orderByReceiveDate` - 受信日時による並び順
     - `GET /api/v1/jobs/continue` - 継続ページネーション（JWTトークンベース）
 
 ##### `hello-work-job-searcher`
 
-- **目的**: ユーザーインターフェース
+- **役割**: ユーザーインターフェース
 - **技術**:
   - React (v19.1.1)
-  - Next.js (v15.5.2) - App Router
+  - Next.js (v15.5.3) - App Router
   - TypeScript (v5)
   - Turbopack - 開発時高速化
   - TanStack React Virtual (v3.13.12) - 仮想化による無限スクロール
@@ -374,9 +374,9 @@ pnpm start          # 本番環境での起動確認
 
 #### エンドポイント
 
-- `POST /api/v1/job` - 求人情報登録
-- `GET /api/v1/job/:jobNumber` - 求人詳細取得
-- `GET /api/v1/jobs?companyName={name}&jobDescription={keyword}&jobDescriptionExclude={exclude}&employeeCountGt={min}&employeeCountLt={max}` - 求人一覧取得（高度なフィルタリング対応）
+- `POST /api/v1/jobs/` - 求人情報登録
+- `GET /api/v1/jobs/:jobNumber` - 求人詳細取得
+- `GET /api/v1/jobs/?companyName={name}&jobDescription={keyword}&jobDescriptionExclude={exclude}&employeeCountGt={min}&employeeCountLt={max}&onlyNotExpired={bool}&orderByReceiveDate={asc|desc}` - 求人一覧取得（高度なフィルタリング対応）
 - `GET /api/v1/jobs/continue?nextToken={token}` - 継続ページネーション（JWTトークンベース、15分有効期限）
 
 #### プロキシAPI（フロントエンド）

--- a/apps/hello-work-job-searcher/README.md
+++ b/apps/hello-work-job-searcher/README.md
@@ -2,47 +2,148 @@
 
 ハローワークの求人情報を検索・閲覧できるNext.jsアプリケーションです。
 
-## 機能
+## 概要
 
-- 求人情報の検索・一覧表示
-- お気に入り機能
-- レスポンシブデザイン
+React 19とNext.js 15の最新技術スタックを採用したモダンなWebアプリケーション。TanStack React Virtualによる仮想化、Jotaiによる効率的な状態管理、neverthrowによる型安全なエラーハンドリングを実現しています。
 
 ## 技術スタック
 
-- Next.js 14 (App Router)
-- TypeScript
-- CSS Modules
-- React
+- **フレームワーク**: Next.js (v15.5.3) - App Router
+- **ライブラリ**: React (v19.1.1)
+- **言語**: TypeScript (v5)
+- **開発ツール**: Turbopack - 高速な開発サーバー
+- **仮想化**: TanStack React Virtual (v3.13.12)
+- **状態管理**: Jotai (v2.13.1)
+- **エラーハンドリング**: neverthrow (v8.2.0)
+- **バリデーション**: Valibot (v1.1.0)
+- **API**: Hono (v4.8.3) - プロキシAPI兼RPC実装
+- **テスト**: Playwright (v1.55.0)
+- **スタイリング**: CSS Modules
+
+## 主要機能
+
+### 完成済み機能
+
+- ✅ 求人一覧表示（仮想化無限スクロール）
+- ✅ 求人詳細ページ（動的ルーティング `/jobs/[jobNumber]`）
+- ✅ 高度な検索・フィルタリング機能
+  - 会社名検索（リアルタイム、デバウンス機能付き）
+  - 職務内容キーワード検索
+  - 除外キーワード検索
+  - 従業員数範囲フィルタ（1-9人、10-30人、30-100人、100人以上）
+  - 期限切れ求人の除外フィルタ
+- ✅ お気に入り機能（localStorage永続化）
+- ✅ お気に入り求人の一覧表示・管理（専用ページ `/favorites`）
+- ✅ サーバーサイドレンダリング（SSR）による初期データプリロード
+- ✅ TanStack React Virtualによる仮想化とスクロール位置保持
+- ✅ レスポンシブデザイン
 
 ## 開発環境のセットアップ
+
+### 前提条件
+
+- Node.js (推奨: 最新LTS版)
+- pnpm (v10.15.1以上)
+
+### インストール
 
 ```bash
 # 依存関係のインストール
 pnpm install
+```
 
-# 開発サーバーの起動
+### 環境変数の設定
+
+`.env.sample`を参考に`.env.local`ファイルを作成してください。
+
+### 開発サーバーの起動
+
+```bash
+# Turbopack対応の開発サーバー（ポート9002で起動）
 pnpm dev
 ```
 
-ブラウザで [http://localhost:3000](http://localhost:3000) を開いてアプリケーションを確認できます。
+ブラウザで [http://localhost:9002](http://localhost:9002) を開いてアプリケーションを確認できます。
+
+### ビルド
+
+```bash
+# 本番用ビルド
+pnpm build
+
+# 本番環境での起動
+pnpm start
+```
+
+### テスト実行
+
+```bash
+# PlaywrightによるE2Eテスト
+pnpm test
+
+# 型チェック
+pnpm type-check
+```
 
 ## プロジェクト構成
 
 ```
 src/
 ├── app/
-│   ├── components/     # 共通コンポーネント
-│   ├── jobs/          # 求人関連ページ
-│   ├── favorites/     # お気に入り機能
-│   ├── hooks/         # カスタムフック
-│   ├── store/         # 状態管理
-│   └── styles/        # グローバルスタイル
+│   ├── api/                       # プロキシAPI
+│   │   └── [[...route]]/          # Catch-allルート
+│   ├── components/                # 共通コンポーネント
+│   │   ├── client/                # クライアントコンポーネント
+│   │   └── NavHeader/             # ナビゲーションヘッダー
+│   ├── favorites/                 # お気に入りページ
+│   ├── hooks/                     # カスタムフック
+│   ├── jobs/                      # 求人関連ページ
+│   │   └── [jobNumber]/           # 動的ルーティング
+│   ├── store/                     # Jotai状態管理
+│   ├── styles/                    # グローバルスタイル
+│   ├── layout.tsx                 # ルートレイアウト
+│   ├── page.tsx                   # トップページ
+│   └── util.ts                    # ユーティリティ関数
+└── tests/                         # E2Eテスト
 ```
+
+## アーキテクチャ
+
+### ハイブリッドデータフェッチング
+
+サーバーサイドレンダリング（SSR）とクライアントサイドフェッチングを組み合わせた効率的なデータ取得を実現：
+
+- **初回ロード**: SSRによる初期データプリロード
+- **以降の操作**: クライアントサイドでの動的フェッチング
+
+### 仮想化による最適化
+
+TanStack React Virtualを使用し、大量の求人データを効率的に表示：
+
+- メモリ使用量の削減
+- スムーズなスクロール体験
+- スクロール位置の保持
+
+### プロキシAPI設計
+
+フロントエンドとバックエンドAPIの間にプロキシレイヤーを配置：
+
+- CORS問題の回避
+- APIキーの秘匿化
+- 型安全なRPC実装（Hono）
+- エラーハンドリングの一元管理
+
+### 状態管理（Jotai）
+
+効率的なatom分離設計：
+
+- `jobListAtom`: 求人一覧データ
+- `JobOverviewListAtom`: 求人概要リスト
+- `favoriteJobsAtom`: お気に入り求人（localStorage永続化）
 
 ## スタイリング
 
-- CSS Modulesを使用
+- CSS Modulesを使用したスコープ付きスタイル
 - レスポンシブデザイン対応
 - アクセシビリティを考慮したカラーパレット
 
@@ -50,4 +151,10 @@ src/
 
 Vercelプラットフォームでのデプロイを推奨します。
 
+デプロイ済みURL: https://my-hello-work-job-list-hello-work-j.vercel.app/
+
 詳細は [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) を参照してください。
+
+## ライセンス
+
+ISC

--- a/apps/job-store-api/README.md
+++ b/apps/job-store-api/README.md
@@ -1,0 +1,169 @@
+# Job Store API
+
+求人情報を管理するCloudflare Workers上で動作するREST APIです。
+
+## 概要
+
+Cloudflare WorkersとD1（SQLite）を使用した軽量なREST API。Honoフレームワークを採用し、型安全なバリデーションとOpenAPI仕様書の自動生成を実現しています。
+
+## 技術スタック
+
+- **実行環境**: Cloudflare Workers
+- **Webフレームワーク**: Hono (v4.8.3)
+- **データベース**: Cloudflare D1 (SQLite)
+- **ORM**: Drizzle ORM (v0.44.2)
+- **バリデーション**: Valibot (v1.1.0)
+- **エラーハンドリング**: neverthrow (v8.2.0)
+- **OpenAPI**: hono-openapi (v1.0.8) + @hono/swagger-ui (v0.5.2)
+- **ビルドツール**: tsdown (v0.15.3)
+- **デプロイツール**: Wrangler (v4.38.0)
+- **テスト**: Vitest (v3.2.4)
+
+## 主要機能
+
+### OpenAPI仕様書の自動生成
+
+- `/docs` - Swagger UIによるインタラクティブなAPI仕様書
+- `/openapi` - OpenAPIスキーマのJSON出力
+- ルートパス (`/`) から自動的にドキュメントページへリダイレクト
+
+### RESTful API エンドポイント
+
+#### 求人情報登録
+- `POST /api/v1/jobs/`
+- APIキー認証が必要（`x-api-key`ヘッダー）
+
+#### 求人詳細取得
+- `GET /api/v1/jobs/:jobNumber`
+- 指定した求人番号の詳細情報を取得
+
+#### 求人一覧取得（高度なフィルタリング対応）
+- `GET /api/v1/jobs/`
+- クエリパラメータ:
+  - `companyName` - 会社名フィルタ（部分一致、URLエンコード対応）
+  - `jobDescription` - 職務内容キーワード検索
+  - `jobDescriptionExclude` - 除外キーワード検索
+  - `employeeCountGt` - 従業員数範囲フィルタ（下限）
+  - `employeeCountLt` - 従業員数範囲フィルタ（上限）
+  - `onlyNotExpired` - 期限切れ求人の除外
+  - `orderByReceiveDate` - 受信日時による並び順（`asc` または `desc`）
+
+#### 継続ページネーション
+- `GET /api/v1/jobs/continue?nextToken={token}`
+- JWTトークンベースのページネーション（15分有効期限）
+
+## 開発環境のセットアップ
+
+### 前提条件
+
+- Node.js (推奨: 最新LTS版)
+- pnpm (v10.15.1以上)
+- Cloudflare アカウント
+- Wrangler CLI
+
+### インストール
+
+```bash
+# 依存関係のインストール
+pnpm install
+
+# 型定義の生成
+pnpm cf-typegen
+```
+
+### 開発サーバーの起動
+
+```bash
+# ローカルD1データベースにリモートデータをダンプして開発サーバーを起動
+pnpm dev
+```
+
+ブラウザで [http://localhost:8787](http://localhost:8787) を開いてAPIドキュメントを確認できます。
+
+### テスト実行
+
+```bash
+# 単体テスト
+pnpm test
+
+# 型チェック
+pnpm type-check
+```
+
+## ビルド・デプロイ
+
+### ビルド
+
+```bash
+pnpm build
+```
+
+### デプロイ
+
+```bash
+# Cloudflare Workersにデプロイ
+pnpm deploy
+```
+
+## データベース管理
+
+### マイグレーション
+
+Drizzle Kitを使用してデータベースマイグレーションを管理します。
+
+```bash
+# スキーマ変更を適用
+pnpm exec drizzle-kit generate
+
+# マイグレーションを実行
+pnpm exec wrangler d1 migrations apply job-store
+```
+
+### リモートデータのダンプ
+
+```bash
+# リモートD1データベースからデータをエクスポート
+pnpm dump-remote-data
+```
+
+### スキーマのコピー
+
+```bash
+# スキーマを他のパッケージにコピー
+pnpm copy-schema
+```
+
+## トラブルシューティング
+
+### ローカル開発時にD1エラーが発生する場合
+
+```bash
+# リモートデータを再ダンプ
+pnpm dump-remote-data
+
+# 開発サーバーを再起動
+pnpm dev
+```
+
+### マイグレーションエラー
+
+```bash
+# マイグレーション履歴を確認
+pnpm exec wrangler d1 migrations list job-store
+
+# 手動でマイグレーションを適用
+pnpm exec wrangler d1 migrations apply job-store --remote
+```
+
+## 環境変数
+
+以下の環境変数が必要です（`wrangler.jsonc`または`.dev.vars`で設定）：
+
+```bash
+API_KEY=<API認証キー>
+JWT_SECRET=<JWT署名用シークレット>
+```
+
+## ライセンス
+
+ISC

--- a/packages/models/README.md
+++ b/packages/models/README.md
@@ -1,0 +1,147 @@
+# @sho/models
+
+モノレポ全体で共有される型定義・スキーマパッケージです。
+
+## 概要
+
+`@sho/models`は、フロントエンド、バックエンド、データベース間で型の一貫性を保つための中核パッケージです。Valibotスキーマ、Drizzle ORMスキーマ、TypeScript型定義を一元管理し、全パッケージの**Source of Truth**として機能します。
+
+## 技術スタック
+
+- **TypeScript** (v5.8.3) - 型定義
+- **Valibot** (v1.1.0) - ランタイムスキーマバリデーション
+- **Drizzle ORM** (v0.44.2) - データベーススキーマ定義
+- **tsdown** (v0.15.3) - ビルドツール
+- **Playwright** (v1.53.1) - テスト用ブラウザ自動化（devDependency）
+
+## パッケージ構成
+
+```
+src/
+├── common.ts                  # 共通型定義
+├── index.ts                   # エクスポート
+├── frontend/                  # フロントエンド向け型定義
+│   ├── index.ts
+│   └── type.ts
+├── headless-crawler/          # クローラー向け型定義
+│   ├── index.ts
+│   ├── scraper.ts
+│   └── type.ts
+├── job-store/                 # API/DB向け型定義
+│   ├── client.ts
+│   ├── drizzle.ts             # Drizzle ORMスキーマ
+│   ├── index.ts
+│   ├── jobFetch.ts
+│   ├── jobInsert.ts
+│   ├── tmp.ts
+│   ├── type.ts
+│   └── jobList/
+```
+
+## 主要機能
+
+### 1. 型の一元管理
+
+すべてのパッケージが`@sho/models`から型定義をインポートすることで、型の整合性を担保します。
+
+```typescript
+// 各パッケージでの使用例
+import { JobListResponse, InsertJobRequestBody } from '@sho/models';
+```
+
+### 2. Valibotスキーマバリデーション
+
+ランタイムでのデータ検証をValibotスキーマで実現します。
+
+```typescript
+import { insertJobRequestBodySchema } from '@sho/models';
+import * as v from 'valibot';
+
+const result = v.safeParse(insertJobRequestBodySchema, data);
+if (result.success) {
+  // 型安全に使用可能
+  const validatedData = result.output;
+}
+```
+
+### 3. Drizzle ORMスキーマ
+
+データベーステーブル定義をDrizzle ORMスキーマとして管理します。
+
+```typescript
+import { jobsTable } from '@sho/models';
+
+// データベース操作で使用
+const jobs = await db.select().from(jobsTable);
+```
+
+## ビルド
+
+```bash
+# TypeScriptをビルド
+pnpm build
+
+# 型チェック
+pnpm type-check
+```
+
+ビルドされたファイルは`dist/`ディレクトリに出力されます：
+- `dist/index.mjs` - ESM形式
+- `dist/index.js` - CommonJS形式
+- `dist/index.d.ts` - 型定義ファイル
+
+## 使用方法
+
+### 他のパッケージから利用
+
+```json
+// package.json
+{
+  "dependencies": {
+    "@sho/models": "workspace:*"
+  }
+}
+```
+
+```typescript
+// TypeScriptファイル内
+import { 
+  JobListResponse,
+  insertJobRequestBodySchema,
+  jobsTable 
+} from '@sho/models';
+```
+
+### 型定義の追加
+
+1. 適切なディレクトリ配下に型定義を追加
+2. `src/index.ts`からエクスポート
+3. `pnpm build`でビルド
+4. 他のパッケージで利用可能に
+
+## 設計思想
+
+### モノレポにおけるSource of Truth
+
+`@sho/models`は、以下の理由から型定義の唯一の情報源（Source of Truth）として機能します：
+
+- **一貫性**: すべてのパッケージが同じ型定義を参照
+- **変更容易性**: 型定義の変更が一箇所で完結
+- **コンパイル時チェック**: 型の不整合をコンパイル時に検出
+- **ランタイム検証**: Valibotによる実行時のデータ検証
+
+### 型安全性の徹底
+
+- TypeScript strict mode有効化
+- Valibotスキーマによるランタイムバリデーション
+- Drizzle ORMによるデータベース操作の型安全性
+
+## 注意事項
+
+- `@sho/models`を変更した後は、必ず`pnpm build`を実行してください
+- 破壊的な型変更を行う場合は、依存するすべてのパッケージの影響を確認してください
+- Drizzle ORMスキーマを変更した場合は、マイグレーションの生成・適用が必要です
+
+## ライセンス
+
+ISC


### PR DESCRIPTION
新規作成:
- apps/job-store-api/README.md: Cloudflare Workers APIの詳細なドキュメントを追加
- packages/models/README.md: 共通型定義パッケージのドキュメントを追加

更新:
- README.md: パッケージバージョンを最新化（Next.js 15.5.3, Wrangler 4.38.0など）、APIエンドポイントを修正（/api/v1/jobs/に統一）
- PORTFOLIO_DETAIL.md: @sho/modelsの技術スタックをValibotベースに更新、AWS CDKバージョンを正確に記載
- apps/hello-work-job-searcher/README.md: 技術スタック、アーキテクチャ、完成済み機能の詳細を大幅に拡充

主な修正点:
- Zod依存からValibotへの移行を反映
- APIエンドポイントのパス修正（/api/v1/job → /api/v1/jobs/）
- 各パッケージの正確なバージョン番号を記載