### PR TITLE
refactor(headless-crawler): ExtractThenTransformThenLoadのconstruct名・フ…

### DIFF
--- a/apps/headless-crawler/infra/stacks/headless-crawler-stack.ts
+++ b/apps/headless-crawler/infra/stacks/headless-crawler-stack.ts
@@ -34,13 +34,14 @@ export class HeadlessCrawlerStack extends cdk.Stack {
       },
     );
 
-    const jobDetailExtractThenTransformThenLoad = new JobDetailExtractThenTransformThenLoadConstruct(
-      this,
-      "JobDetailExtractThenTransformThenLoad",
-      {
-        playwrightLayer: playwrightLayer.layer,
-      },
-    );
+    const jobDetailExtractThenTransformThenLoad =
+      new JobDetailExtractThenTransformThenLoadConstruct(
+        this,
+        "JobDetailExtractThenTransformThenLoad",
+        {
+          playwrightLayer: playwrightLayer.layer,
+        },
+      );
 
     const jobDetailRawHtmlExtractor = new JobDetailRawHtmlExtractorConstruct(
       this,
@@ -56,14 +57,18 @@ export class HeadlessCrawlerStack extends cdk.Stack {
     });
 
     // example resource
-    const toJobDetailExtractThenTransformThenLoadQueue = new sqs.Queue(this, "ToJobDetailExtractThenTransformThenLoadQueue", {
-      visibilityTimeout: cdk.Duration.seconds(300),
-      // リトライ機構を追加（3回リトライ後にデッドレターキューに送信）
-      deadLetterQueue: {
-        queue: deadLetterQueue,
-        maxReceiveCount: 3, // 3回失敗したらデッドレターキューに送信
+    const toJobDetailExtractThenTransformThenLoadQueue = new sqs.Queue(
+      this,
+      "ToJobDetailExtractThenTransformThenLoadQueue",
+      {
+        visibilityTimeout: cdk.Duration.seconds(300),
+        // リトライ機構を追加（3回リトライ後にデッドレターキューに送信）
+        deadLetterQueue: {
+          queue: deadLetterQueue,
+          maxReceiveCount: 3, // 3回失敗したらデッドレターキューに送信
+        },
       },
-    });
+    );
 
     const queueForJobDetailRawHtmlExtractor = new sqs.Queue(
       this,
@@ -140,7 +145,9 @@ export class HeadlessCrawlerStack extends cdk.Stack {
 
     rule.addTarget(new targets.LambdaFunction(jobNumberExtractor.extractor));
 
-    toJobDetailExtractThenTransformThenLoadQueue.grantSendMessages(jobNumberExtractor.extractor);
+    toJobDetailExtractThenTransformThenLoadQueue.grantSendMessages(
+      jobNumberExtractor.extractor,
+    );
     queueForJobDetailRawHtmlExtractor.grantSendMessages(
       jobNumberExtractor.extractor,
     );


### PR DESCRIPTION
## 概要

- Lambda/CDK constructの命名にミスがあったため、より正確かつ一貫性のある名前に修正しました。
- 命名規則の見直しは、今後のリファクタリングや保守性向上の指標にもなります。

## 主な変更点

- `apps/headless-crawler/infra/constructs/jobDetailExtractor.ts` → `jobDetailExtractThenTransformThenLoad.ts` へリネーム
- クラス名・エクスポート名を `JobDetailExtractThenTransformThenLoad` に修正
- `headless-crawler-stack.ts` 内の参照も新しい名前に合わせて修正

## 目的・背景

- Lambdaの役割（抽出→変換→保存）を明確に表現するため、命名をより具体的にしました
- 命名規則の統一を図ることで、今後のリファクタリングや保守作業の指標とします

## 補足

- 機能追加やロジック変更はありません。命名・構造の整理のみです。