### PR TITLE
chore: 複数appでエラーメッセージを詳細化

### DIFF
--- a/apps/headless-crawler/functions/extractTransformAndSaveJobDetailHandler/helper.ts
+++ b/apps/headless-crawler/functions/extractTransformAndSaveJobDetailHandler/helper.ts
@@ -35,7 +35,7 @@ const safeParseFromExtractJobNumberJobQueueEventBodySchema = (val: unknown) => {
   if (!result.success) {
     return Effect.fail(
       new FromExtractJobNumberJobQueueEventBodySchemaValidationError({
-        message: `parse failed. \n${String(result.issues.join("\n"))}`,
+        message: `parse failed. recevied\n ${JSON.stringify(val)}\n${String(result.issues.join("\n"))}`,
       }),
     );
   }

--- a/apps/headless-crawler/lib/core/page/JobDetail/validators/index.ts
+++ b/apps/headless-crawler/lib/core/page/JobDetail/validators/index.ts
@@ -51,7 +51,7 @@ export function validateJobNumber(val: unknown) {
       );
       return yield* Effect.fail(
         new JobNumberValidationError({
-          message: result.issues.join("\n"),
+          message: `parse error. received=${JSON.stringify(val)}\n${result.issues.join("\n")}`,
         }),
       );
     }
@@ -64,7 +64,7 @@ export function validateCompanyName(val: unknown) {
     const result = v.safeParse(companyNameSchema, val);
     if (!result.success) {
       return yield* Effect.fail(
-        new CompanyNameValidationError({ message: result.issues.join("\n") }),
+        new CompanyNameValidationError({ message: `parse error. received=${JSON.stringify(val)}\n${result.issues.join("\n")}` }),
       ).pipe(
         Effect.tap(() => {
           return Effect.logDebug(
@@ -86,7 +86,7 @@ export function validateReceivedDate(val: unknown) {
     const result = v.safeParse(RawReceivedDateShema, val);
     if (!result.success) {
       return yield* Effect.fail(
-        new ReceivedDateValidationError({ message: result.issues.join("\n") }),
+        new ReceivedDateValidationError({ message: `parse error. received=${JSON.stringify(val)}\n${result.issues.join("\n")}` }),
       ).pipe(
         Effect.tap(() => {
           Effect.logDebug(
@@ -107,7 +107,7 @@ export function validateExpiryDate(val: unknown) {
     const result = v.safeParse(RawExpiryDateSchema, val);
     if (!result.success) {
       return yield* Effect.fail(
-        new ExpiryDateValidationError({ message: result.issues.join("\n") }),
+        new ExpiryDateValidationError({ message: `parse error. received=${JSON.stringify(val)}\n${result.issues.join("\n")}` }),
       ).pipe(
         Effect.tap(() => {
           Effect.logDebug(
@@ -128,7 +128,7 @@ export function validateHomePage(val: unknown) {
     const result = v.safeParse(homePageSchema, val);
     if (!result.success) {
       return yield* Effect.fail(
-        new HomePageValidationError({ message: result.issues.join("\n") }),
+        new HomePageValidationError({ message: `parse error. received=${JSON.stringify(val)}\n${result.issues.join("\n")}` }),
       ).pipe(
         Effect.tap(() => {
           Effect.logDebug(
@@ -156,7 +156,7 @@ export function validateOccupation(val: unknown) {
         `failed to validate occupation. issues=${JSON.stringify(result.issues, null, 2)}`,
       );
       return yield* Effect.fail(
-        new OccupationValidationError({ message: result.issues.join("\n") }),
+        new OccupationValidationError({ message: `parse error. received=${JSON.stringify(val)}\n${result.issues.join("\n")}` }),
       ).pipe(
         Effect.tap(() => {
           Effect.logDebug(
@@ -197,7 +197,7 @@ export function validateWage(val: unknown) {
       try: () => v.parse(RawWageSchema, val),
       catch: (e) =>
         e instanceof v.ValiError
-          ? new WageValidationError({ message: e.message })
+          ? new WageValidationError({ message: `parse failed. received=${JSON.stringify(val)}\n${e.message}` })
           : new WageValidationError({
               message: `unexpected error.\n${String(e)}`,
             }),
@@ -216,7 +216,7 @@ export function validateWorkingHours(val: unknown) {
     try: () => v.parse(RawWorkingHoursSchema, val),
     catch: (e) =>
       e instanceof v.ValiError
-        ? new WorkingHoursValidationError({ message: e.message })
+        ? new WorkingHoursValidationError({ message: `parse failed. received=${JSON.stringify(val)}\n${e.message}` })
         : new WorkingHoursValidationError({
             message: `unexpected error.\n${String(e)}`,
           }),
@@ -233,7 +233,7 @@ export function validateEmployeeCount(val: unknown) {
     try: () => v.parse(RawEmployeeCountSchema, val),
     catch: (e) =>
       e instanceof v.ValiError
-        ? new EmployeeCountValidationError({ message: e.message })
+        ? new EmployeeCountValidationError({ message: `parse failed. received=${JSON.stringify(val)}\n${e.message}` })
         : new EmployeeCountValidationError({
             message: `unexpected error.\n${String(e)}`,
           }),
@@ -251,7 +251,7 @@ export function validateWorkPlace(val: unknown) {
     try: () => v.parse(workPlaceSchema, val),
     catch: (e) =>
       e instanceof v.ValiError
-        ? new WorkPlaceValidationError({ message: e.message })
+        ? new WorkPlaceValidationError({ message: `parse failed. received=${JSON.stringify(val)}\n${e.message}` })
         : new WorkPlaceValidationError({
             message: `unexpected error. \n${String(e)}`,
           }),
@@ -269,7 +269,7 @@ export function validateJobDescription(val: unknown) {
     try: () => v.parse(jobDescriptionSchema, val),
     catch: (e) =>
       e instanceof v.ValiError
-        ? new JobDescriptionValidationError({ message: e.message })
+        ? new JobDescriptionValidationError({ message: `parse failed. received=${JSON.stringify(val)}\n${e.message}` })
         : new JobDescriptionValidationError({
             message: `unexpected error.\n${String}`,
           }),
@@ -291,7 +291,7 @@ export function validateQualification(
   const result = v.safeParse(qualificationsSchema, val);
   if (!result.success) {
     return Effect.fail(
-      new QualificationValidationError({ message: result.issues.join("\n") }),
+      new QualificationValidationError({ message: `parse failed. received=${JSON.stringify(val)}\n${result.issues.join("\n")}` }),
     ).pipe(
       Effect.tap(() => {
         Effect.logDebug(

--- a/apps/hello-work-job-searcher/src/app/store/server/index.ts
+++ b/apps/hello-work-job-searcher/src/app/store/server/index.ts
@@ -64,7 +64,7 @@ export const jobStoreClientOnServer: JobStoreClient = {
         if (!result.success) {
           return err(
             createValidateJobsError(
-              `Invalid job query: ${result.issues.map((issue) => issue.message).join("\n")}`,
+              `Invalid job query. received:  ${JSON.stringify(paramsObj, null, 2)}\n${result.issues.map((issue) => issue.message).join("\n")}`,
             ),
           );
         }
@@ -93,7 +93,7 @@ export const jobStoreClientOnServer: JobStoreClient = {
         if (!result.success) {
           return err(
             createValidateJobsError(
-              `Invalid job data: ${result.issues.map((issue) => issue.message).join("\n")}`,
+              `Invalid job data. received: ${JSON.stringify(data, null, 2)}\n${result.issues.map((issue) => issue.message).join("\n")}`,
             ),
           );
         }
@@ -137,7 +137,7 @@ export const jobStoreClientOnServer: JobStoreClient = {
         if (!result.success) {
           return err(
             createValidateJobsError(
-              `Invalid job data: ${result.issues.map((issue) => issue.message).join("\n")}`,
+              `Invalid job data. received: ${JSON.stringify(data, null, 2)}\n${result.issues.map((issue) => issue.message).join("\n")}`,
             ),
           );
         }

--- a/apps/job-store-api/src/routes/api/v1/jobs/continue/index.ts
+++ b/apps/job-store-api/src/routes/api/v1/jobs/continue/index.ts
@@ -71,7 +71,7 @@ app.get(
         if (!result.success)
           return err(
             createEnvError(
-              `Environment variable validation failed: ${String(result.issues)}`,
+              `Environment variable validation failed. received: ${JSON.stringify(c.env)}\n${String(result.issues)}`,
             ),
           );
         return ok(result.output);
@@ -89,7 +89,7 @@ app.get(
       if (!payloadValidation.success) {
         return err(
           createDecodeJWTPayloadError(
-            `Decoding JWT payload failed.\n${String(payloadValidation.issues.map((i) => i.message).join("\n"))}`,
+            `Decoding JWT payload failed. received: ${JSON.stringify(decodeResult.payload)}\n${String(payloadValidation.issues.map((i) => i.message).join("\n"))}`,
           ),
         );
       }

--- a/apps/job-store-api/src/routes/api/v1/jobs/index.ts
+++ b/apps/job-store-api/src/routes/api/v1/jobs/index.ts
@@ -255,7 +255,7 @@ app.get("/", jobListRoute, vValidator("query", jobListQuerySchema), (c) => {
       if (!result.success)
         return err(
           createEmployeeCountGtValidationError(
-            `Invalid employeeCountGt.${result.issues.map((issue) => issue.message).join("\n")}`,
+            `Invalid employeeCountGt. received: ${JSON.stringify(rawEmployeeCountGt)}\n${result.issues.map((issue) => issue.message).join("\n")}`,
           ),
         );
       return ok(result.output);
@@ -269,7 +269,7 @@ app.get("/", jobListRoute, vValidator("query", jobListQuerySchema), (c) => {
       if (!result.success)
         return err(
           createEmployeeCountLtValidationError(
-            `Invalid employeeCountLt.${result.issues.map((issue) => issue.message).join("\n")}`,
+            `Invalid employeeCountLt. received: ${JSON.stringify(rawEmployeeCountLt)}\n${result.issues.map((issue) => issue.message).join("\n")}`,
           ),
         );
       return ok(result.output);
@@ -279,7 +279,7 @@ app.get("/", jobListRoute, vValidator("query", jobListQuerySchema), (c) => {
       if (!result.success)
         return err(
           createEnvError(
-            `Environment variable validation failed: ${String(result.issues)}`,
+            `Environment variable validation failed. received: ${JSON.stringify(c.env)}\n${String(result.issues)}`,
           ),
         );
       return ok(result.output);


### PR DESCRIPTION
- job-store-api, headless-crawler, hello-work-job-searcher等でバリデーション・JWT等のエラー出力を詳細化
- 受信値やパース失敗内容を含めてデバッグ性を向上
- ロジック自体の変更はなし（メッセージ改善のみ）