### PR TITLE
chore(headless-crawler): roughMaxCountを200→400に増加

### DIFF
--- a/apps/headless-crawler/lib/config/crawler.ts
+++ b/apps/headless-crawler/lib/config/crawler.ts
@@ -6,7 +6,7 @@ export default defineHelloWorkCrawlingConfig(async () => {
     ? await import("@sparticuz/chromium").then((mod) => mod.default)
     : null;
   return {
-    roughMaxCount: 200,
+    roughMaxCount: 400,
     browserConfig: {
       executablePath: chromium ? await chromium.executablePath() : undefined,
       args: chromium ? chromium.args : [],


### PR DESCRIPTION
## 概要

- クローラの最大取得件数（`roughMaxCount`）を200から400に増加しました。

## 主な変更点

- `apps/headless-crawler/lib/config/crawler.ts` の `roughMaxCount` を 200 → 400 に変更

## 目的・背景

- 前回の設定では取得件数が少なく、取りこぼしが多い可能性があったため、件数を増やしてカバレッジを向上させる狙い
- 今後も状況に応じて更に増加させていく予定

## 補足

- 機能追加やロジック変更はありません（パラメータ値の変更のみ）
- テストは型チェックのみ実施しています