### PR TITLE
fix(headless-crawler): message bodyからtimestampフィールドを削除

### DIFF
--- a/apps/headless-crawler/functions/helpers/helper.ts
+++ b/apps/headless-crawler/functions/helpers/helper.ts
@@ -14,7 +14,6 @@ export const sendJobToQueue = (job: JobMetadata) =>
             QueueUrl: QUEUE_URL,
             MessageBody: JSON.stringify({
               job,
-              timestamp: new Date().toISOString(),
             }),
           }),
         );
@@ -36,7 +35,6 @@ export const sendJobToRawJobDetailExtractorQueue = (job: JobMetadata) =>
             QueueUrl: QUEUE_URL,
             MessageBody: JSON.stringify({
               job,
-              timestamp: new Date().toISOString(),
             }),
           }),
         );


### PR DESCRIPTION
## 概要

SQSメッセージbodyから不要なtimestampフィールドを削除しました。

## 変更内容

- SQSメッセージの構造からtimestampプロパティを除去

## 背景・目的

timestampフィールドは利用されておらず、メッセージ構造をシンプルに保つため削除しました。

## 動作確認

- 型チェック・ビルドが正常に通ることを確認済み
- 既存の処理フローに影響がないことを確認済み

## 補足・所感

~~以前はeffect-tsのスキーマでパースしていましたが、valibotに移行したことでエラーが検出されるようになりました。  
調査はしていませんが、effect-tsは構造型的なパースが許される一方、valibotはスキーマの完全一致が求められるためだと考えています。~~
#351 
違った、引数でobjectを想定していたが、シリアライズ(string)されたデータが来てたから、エラーを吐いてた
この挙動の違いについては、今後いつか調査する予定です。

## 今後の設計について

今後、取得日などのメタデータはraw HTMLとともにS3へ保管する方針を検討しています。