### PR TITLE
feat(headless-crawler): Lambdaのタイムアウトを120秒に延長

### DIFF
--- a/apps/headless-crawler/infra/constructs/jobNumberExtractor.ts
+++ b/apps/headless-crawler/infra/constructs/jobNumberExtractor.ts
@@ -23,7 +23,7 @@ export class JobNumberExtractConstruct extends Construct {
       entry: "functions/extractJobNumberHandler/handler.ts",
       handler: "handler",
       memorySize: 1024,
-      timeout: Duration.seconds(90),
+      timeout: Duration.seconds(120),
       environment: {
         QUEUE_URL: process.env.QUEUE_URL || "",
       },


### PR DESCRIPTION
## 概要
Lambda関数（JobNumberExtractConstruct）のタイムアウト値を90秒から120秒に延長しました。

## 変更内容
- `apps/headless-crawler/infra/constructs/jobNumberExtractor.ts` の `timeout` を `Duration.seconds(120)` に変更

## 背景・目的
クローリング件数が200件を超える場合、従来の90秒では処理がギリギリとなるケースが発生していました。  
タイムアウトによる失敗を防ぐため、余裕を持たせて120秒に延長します。

## 動作確認
- TypeScriptの型チェック・ビルドが正常に完了することを確認済み
- 既存の処理に影響がないことを確認済み
