### PR TITLE
refactor: CDK Constructインスタンス変数名を*Constructで統一

### DIFF
--- a/apps/headless-crawler/infra/stacks/headless-crawler-stack.ts
+++ b/apps/headless-crawler/infra/stacks/headless-crawler-stack.ts
@@ -26,13 +26,10 @@ export class HeadlessCrawlerStack extends cdk.Stack {
       "PlayWrightLayer",
     );
 
-    const jobNumberExtractorConstruct = new JobNumberExtractAndTransformConstruct(
-      this,
-      "JobNumberExtractor",
-      {
+    const jobNumberExtractorConstruct =
+      new JobNumberExtractAndTransformConstruct(this, "JobNumberExtractor", {
         playwrightLayer: playwrightLayer.layer,
-      },
-    );
+      });
 
     const jobDetailExtractThenTransformThenLoadConstruct =
       new JobDetailExtractThenTransformThenLoadConstruct(
@@ -43,13 +40,14 @@ export class HeadlessCrawlerStack extends cdk.Stack {
         },
       );
 
-    const jobDetailRawHtmlExtractorConstruct = new JobDetailRawHtmlExtractorConstruct(
-      this,
-      "JobDetailRawHtmlExtractor",
-      {
-        playwrightLayer: playwrightLayer.layer,
-      },
-    );
+    const jobDetailRawHtmlExtractorConstruct =
+      new JobDetailRawHtmlExtractorConstruct(
+        this,
+        "JobDetailRawHtmlExtractor",
+        {
+          playwrightLayer: playwrightLayer.layer,
+        },
+      );
 
     // デッドレターキューを作成
     const deadLetterQueue = new sqs.Queue(this, "ScrapingJobDeadLetterQueue", {
@@ -143,7 +141,9 @@ export class HeadlessCrawlerStack extends cdk.Stack {
       }),
     );
 
-    rule.addTarget(new targets.LambdaFunction(jobNumberExtractorConstruct.extractor));
+    rule.addTarget(
+      new targets.LambdaFunction(jobNumberExtractorConstruct.extractor),
+    );
 
     toJobDetailExtractThenTransformThenLoadQueue.grantSendMessages(
       jobNumberExtractorConstruct.extractor,

--- a/apps/headless-crawler/infra/stacks/headless-crawler-stack.ts
+++ b/apps/headless-crawler/infra/stacks/headless-crawler-stack.ts
@@ -26,7 +26,7 @@ export class HeadlessCrawlerStack extends cdk.Stack {
       "PlayWrightLayer",
     );
 
-    const jobNumberExtractor = new JobNumberExtractAndTransformConstruct(
+    const jobNumberExtractorConstruct = new JobNumberExtractAndTransformConstruct(
       this,
       "JobNumberExtractor",
       {
@@ -34,7 +34,7 @@ export class HeadlessCrawlerStack extends cdk.Stack {
       },
     );
 
-    const jobDetailExtractThenTransformThenLoad =
+    const jobDetailExtractThenTransformThenLoadConstruct =
       new JobDetailExtractThenTransformThenLoadConstruct(
         this,
         "JobDetailExtractThenTransformThenLoad",
@@ -43,7 +43,7 @@ export class HeadlessCrawlerStack extends cdk.Stack {
         },
       );
 
-    const jobDetailRawHtmlExtractor = new JobDetailRawHtmlExtractorConstruct(
+    const jobDetailRawHtmlExtractorConstruct = new JobDetailRawHtmlExtractorConstruct(
       this,
       "JobDetailRawHtmlExtractor",
       {
@@ -132,24 +132,24 @@ export class HeadlessCrawlerStack extends cdk.Stack {
     deadLetterQueue.grantConsumeMessages(deadLetterMonitor);
     deadLetterMonitorAlarmTopic.grantPublish(deadLetterMonitor);
 
-    jobDetailExtractThenTransformThenLoad.extractThenTransformThenLoader.addEventSource(
+    jobDetailExtractThenTransformThenLoadConstruct.extractThenTransformThenLoader.addEventSource(
       new SqsEventSource(toJobDetailExtractThenTransformThenLoadQueue, {
         batchSize: 1,
       }),
     );
-    jobDetailRawHtmlExtractor.extractor.addEventSource(
+    jobDetailRawHtmlExtractorConstruct.extractor.addEventSource(
       new SqsEventSource(queueForJobDetailRawHtmlExtractor, {
         batchSize: 1,
       }),
     );
 
-    rule.addTarget(new targets.LambdaFunction(jobNumberExtractor.extractor));
+    rule.addTarget(new targets.LambdaFunction(jobNumberExtractorConstruct.extractor));
 
     toJobDetailExtractThenTransformThenLoadQueue.grantSendMessages(
-      jobNumberExtractor.extractor,
+      jobNumberExtractorConstruct.extractor,
     );
     queueForJobDetailRawHtmlExtractor.grantSendMessages(
-      jobNumberExtractor.extractor,
+      jobNumberExtractorConstruct.extractor,
     );
   }
 }


### PR DESCRIPTION
## 概要

CDK Constructインスタンス変数名を `*Construct` サフィックスで統一しました。  
スタック内でのConstructインスタンスの識別が明確になり、可読性・保守性が向上します。

## 主な変更点

- `jobNumberExtractor` → `jobNumberExtractorConstruct`
- `jobDetailExtractThenTransformThenLoad` → `jobDetailExtractThenTransformThenLoadConstruct`
- `jobDetailRawHtmlExtractor` → `jobDetailRawHtmlExtractorConstruct`
- それぞれの参照箇所も新しい変数名に修正

## 背景・目的

- CDKプロジェクトの命名規則を統一し、今後の開発・運用での混乱を防ぐため
- インスタンス変数名とクラス名の対応を明確にすることで、コードリーディングやリファクタ時の負担を軽減

## 補足

- 機能追加やロジックの変更はありません（リファクタのみ）
- テスト・ビルドは全て正常に通過しています