### PR TITLE
refactor: SQS送信ヘルパーの汎用化とスキーマ簡素化

### DIFF
--- a/apps/headless-crawler/functions/E-T-L-JobDetailHandler/helper.ts
+++ b/apps/headless-crawler/functions/E-T-L-JobDetailHandler/helper.ts
@@ -76,9 +76,8 @@ export const fromEventToFirstRecord = ({
           message: `parse body to json failed.\n${e instanceof Error ? e.message : String(e)}`,
         }),
     });
-    const {
-      jobNumber,
-    } = yield* safeParseFromExtractJobNumberJobQueueEventBodySchema(parsed);
+    const { jobNumber } =
+      yield* safeParseFromExtractJobNumberJobQueueEventBodySchema(parsed);
     return jobNumber as JobNumber;
   });
 };

--- a/apps/headless-crawler/functions/E-T-L-JobDetailHandler/helper.ts
+++ b/apps/headless-crawler/functions/E-T-L-JobDetailHandler/helper.ts
@@ -77,7 +77,7 @@ export const fromEventToFirstRecord = ({
         }),
     });
     const {
-      job: { jobNumber },
+      jobNumber,
     } = yield* safeParseFromExtractJobNumberJobQueueEventBodySchema(parsed);
     return jobNumber as JobNumber;
   });

--- a/apps/headless-crawler/functions/E-T-L-JobDetailHandler/schema.ts
+++ b/apps/headless-crawler/functions/E-T-L-JobDetailHandler/schema.ts
@@ -1,7 +1,5 @@
 import * as v from "valibot";
 
 export const fromExtractJobNumberHandlerJobQueueEventBodySchema = v.object({
-  job: v.object({
-    jobNumber: v.string(),
-  }),
+  jobNumber: v.string(),
 });

--- a/apps/headless-crawler/functions/ET-JobNumberHandler/handler.ts
+++ b/apps/headless-crawler/functions/ET-JobNumberHandler/handler.ts
@@ -9,16 +9,13 @@ export const handler: Handler<
   unknown // 型つけるのが面倒くさいので
 > = async (_) => {
   const program = Effect.gen(function* () {
-    const QUEUE_URL = yield* Config.string("QUEUE_URL")
+    const QUEUE_URL = yield* Config.string("QUEUE_URL");
     const jobs = yield* crawlerRunnable;
     yield* Effect.forEach(jobs, (job) =>
-      sendMessageToQueue(
-        { jobNumber: job.jobNumber },
-        QUEUE_URL,
-      )
+      sendMessageToQueue({ jobNumber: job.jobNumber }, QUEUE_URL),
     );
     return jobs;
-  })
+  });
   const exit = await Effect.runPromiseExit(program);
   if (Exit.isSuccess(exit)) {
     console.log("handler succeeded", JSON.stringify(exit.value, null, 2));

--- a/apps/headless-crawler/functions/helpers/helper.ts
+++ b/apps/headless-crawler/functions/helpers/helper.ts
@@ -2,19 +2,22 @@ import { SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
 import type { JobMetadata } from "@sho/models";
 import { Effect } from "effect";
 import { SendSQSMessageError } from "./error";
-
-export const sendJobToQueue = (job: JobMetadata) =>
+export type Serializable =
+  | string
+  | number
+  | boolean
+  | null
+  | Serializable[]
+  | { [key: string]: Serializable };
+export const sendMessageToQueue = (value: Serializable, url: string) =>
   Effect.gen(function* () {
     const sqs = new SQSClient({});
-    const QUEUE_URL = yield* Effect.fromNullable(process.env.QUEUE_URL);
     return yield* Effect.tryPromise({
       try: async () => {
         return await sqs.send(
           new SendMessageCommand({
-            QueueUrl: QUEUE_URL,
-            MessageBody: JSON.stringify({
-              job,
-            }),
+            QueueUrl: url,
+            MessageBody: JSON.stringify(value),
           }),
         );
       },


### PR DESCRIPTION
## 概要

SQS送信ヘルパーの汎用化とスキーマ簡素化を行いました。

## 主な変更点

- `sendJobToQueue` を `sendMessageToQueue` にリネームし、`Serializable` 型で柔軟に送信できるように変更
- SQS送信時のスキーマを `{ jobNumber }` 形式に簡素化
- handler・helperの命名・型・処理を整理

## 背景・目的

- SQS送信処理の再利用性・可読性向上
- スキーマのシンプル化による保守性向上

## テスト

- 静的テスト（型チェック・ビルド）のみ実施済み
- ユニットテスト・結合テストは未実施

## 補足

- 機能追加やロジックの大きな変更はありません（リファクタのみ）