### PR TITLE
refactor: 未使用のSQS送信ヘルパーと型importを削除

### DIFF
--- a/apps/headless-crawler/functions/helpers/helper.ts
+++ b/apps/headless-crawler/functions/helpers/helper.ts
@@ -1,5 +1,4 @@
 import { SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
-import type { JobMetadata } from "@sho/models";
 import { Effect } from "effect";
 import { SendSQSMessageError } from "./error";
 export type Serializable =
@@ -18,27 +17,6 @@ export const sendMessageToQueue = (value: Serializable, url: string) =>
           new SendMessageCommand({
             QueueUrl: url,
             MessageBody: JSON.stringify(value),
-          }),
-        );
-      },
-      catch: (e) =>
-        new SendSQSMessageError({ message: `unexpected error.\n${String(e)}` }),
-    });
-  });
-export const sendJobToRawJobDetailExtractorQueue = (job: JobMetadata) =>
-  Effect.gen(function* () {
-    const sqs = new SQSClient({});
-    const QUEUE_URL = yield* Effect.fromNullable(
-      process.env.RAW_JOB_DETAIL_EXTRACTOR_QUEUE_URL,
-    );
-    return yield* Effect.tryPromise({
-      try: async () => {
-        return await sqs.send(
-          new SendMessageCommand({
-            QueueUrl: QUEUE_URL,
-            MessageBody: JSON.stringify({
-              job,
-            }),
           }),
         );
       },


### PR DESCRIPTION
## 概要

未使用となったSQS送信ヘルパー関数と型importを削除しました。

## 主な変更点

- `sendJobToRawJobDetailExtractorQueue` 関数を削除
- 未使用の `JobMetadata` 型importを削除

## 背景・目的

- 利用されていないヘルパーや型importを整理し、コードベースの保守性・可読性を向上させるため

## 補足

- 機能追加やロジックの変更はありません（不要コードの削除のみ）
- 静的テスト（型チェック・ビルド）は正常に通過しています