### PR TITLE
feat(headless-crawler): JobDetailLoaderの基盤実装を追加

### DIFF
--- a/apps/headless-crawler/lib/L-jobDetail/context.ts
+++ b/apps/headless-crawler/lib/L-jobDetail/context.ts
@@ -8,25 +8,17 @@ import type { InsertJobError } from "./error";
 export class LoaderConfig extends Context.Tag("LoaderConfig")<
   LoaderConfig,
   {}
->() { }
+>() {}
 
-export const configLive = Layer.succeed(
-  LoaderConfig,
-  LoaderConfig.of({}),
-);
+export const configLive = Layer.succeed(LoaderConfig, LoaderConfig.of({}));
 export class JobDetailLoader extends Context.Tag("JobDetailLoader")<
   JobDetailLoader,
   {
     readonly load: (
       data: InferOutput<typeof transformedSchema>,
-    ) => Effect.Effect<
-      void,
-      | ConfigError
-      | InsertJobError,
-      LoaderConfig
-    >;
+    ) => Effect.Effect<void, ConfigError | InsertJobError, LoaderConfig>;
   }
->() { }
+>() {}
 
 export const loaderLive = Layer.effect(
   JobDetailLoader,
@@ -43,9 +35,7 @@ export const loaderLive = Layer.effect(
           yield* Effect.logInfo(
             `start transforming... config=${JSON.stringify(config, null, 2)}`,
           );
-
         }),
     });
   }),
 );
-

--- a/apps/headless-crawler/lib/L-jobDetail/context.ts
+++ b/apps/headless-crawler/lib/L-jobDetail/context.ts
@@ -1,0 +1,51 @@
+import type { transformedSchema } from "@sho/models";
+import { Context, Effect, Layer } from "effect";
+import type { InferOutput } from "valibot";
+import { buildJobStoreClient } from "./helper";
+import type { ConfigError } from "effect/ConfigError";
+import type { InsertJobError } from "./error";
+
+export class LoaderConfig extends Context.Tag("LoaderConfig")<
+  LoaderConfig,
+  {}
+>() { }
+
+export const configLive = Layer.succeed(
+  LoaderConfig,
+  LoaderConfig.of({}),
+);
+export class JobDetailLoader extends Context.Tag("JobDetailLoader")<
+  JobDetailLoader,
+  {
+    readonly load: (
+      data: InferOutput<typeof transformedSchema>,
+    ) => Effect.Effect<
+      void,
+      | ConfigError
+      | InsertJobError,
+      LoaderConfig
+    >;
+  }
+>() { }
+
+export const loaderLive = Layer.effect(
+  JobDetailLoader,
+  Effect.gen(function* () {
+    return JobDetailLoader.of({
+      load: (data: InferOutput<typeof transformedSchema>) =>
+        Effect.gen(function* () {
+          const config = yield* LoaderConfig;
+          yield* Effect.logInfo(
+            `building loader: config=${JSON.stringify(config, null, 2)}`,
+          );
+          const client = yield* buildJobStoreClient();
+          yield* client.insertJob(data);
+          yield* Effect.logInfo(
+            `start transforming... config=${JSON.stringify(config, null, 2)}`,
+          );
+
+        }),
+    });
+  }),
+);
+

--- a/apps/headless-crawler/lib/L-jobDetail/error.ts
+++ b/apps/headless-crawler/lib/L-jobDetail/error.ts
@@ -2,4 +2,4 @@ import { Data } from "effect";
 
 export class InsertJobError extends Data.TaggedError("InsertJobError")<{
   readonly message: string;
-}> { }
+}> {}

--- a/apps/headless-crawler/lib/L-jobDetail/error.ts
+++ b/apps/headless-crawler/lib/L-jobDetail/error.ts
@@ -1,0 +1,5 @@
+import { Data } from "effect";
+
+export class InsertJobError extends Data.TaggedError("InsertJobError")<{
+  readonly message: string;
+}> { }

--- a/apps/headless-crawler/lib/L-jobDetail/helper.ts
+++ b/apps/headless-crawler/lib/L-jobDetail/helper.ts
@@ -2,10 +2,9 @@ import type { InsertJobRequestBody } from "@sho/models";
 import { Config, Effect } from "effect";
 import { InsertJobError } from "./error";
 
-
 export function buildJobStoreClient() {
   return Effect.gen(function* () {
-    const endpoint = yield* Config.string("JOB_STORE_ENDPOINT")
+    const endpoint = yield* Config.string("JOB_STORE_ENDPOINT");
     return {
       insertJob: (job: InsertJobRequestBody) =>
         Effect.gen(function* () {

--- a/apps/headless-crawler/lib/L-jobDetail/helper.ts
+++ b/apps/headless-crawler/lib/L-jobDetail/helper.ts
@@ -1,0 +1,48 @@
+import type { InsertJobRequestBody } from "@sho/models";
+import { Config, Effect } from "effect";
+import { InsertJobError } from "./error";
+
+
+export function buildJobStoreClient() {
+  return Effect.gen(function* () {
+    const endpoint = yield* Config.string("JOB_STORE_ENDPOINT")
+    return {
+      insertJob: (job: InsertJobRequestBody) =>
+        Effect.gen(function* () {
+          yield* Effect.logDebug(
+            `executing insert job api. job=${JSON.stringify(job, null, 2)}`,
+          );
+          const res = yield* Effect.tryPromise({
+            try: async () =>
+              fetch(`${endpoint}/job`, {
+                method: "POST",
+                body: JSON.stringify(job),
+                headers: {
+                  "content-type": "application/json",
+                  "x-api-key": process.env.API_KEY ?? "",
+                },
+              }),
+            catch: (e) =>
+              new InsertJobError({
+                message: `insert job response failed.\n${e instanceof Error ? e.message : String(e)}`,
+              }),
+          });
+          if (!res.ok) {
+            throw new InsertJobError({
+              message: `insert job failed.\nstatus=${res.status}\nstatusText=${res.statusText}`,
+            });
+          }
+          const data = yield* Effect.tryPromise({
+            try: () => res.json(),
+            catch: (e) =>
+              new InsertJobError({
+                message: `insert job transforming json failed.\n${e instanceof Error ? e.message : String(e)}`,
+              }),
+          });
+          yield* Effect.logDebug(
+            `response data. ${JSON.stringify(data, null, 2)}`,
+          );
+        }),
+    };
+  });
+}

--- a/apps/headless-crawler/lib/L-jobDetail/loader.ts
+++ b/apps/headless-crawler/lib/L-jobDetail/loader.ts
@@ -1,0 +1,10 @@
+import { Effect } from "effect";
+import { JobDetailLoader } from "./context";
+import type { InferOutput } from "valibot";
+import type { transformedSchema } from "@sho/models";
+export const buildProgram = (data: InferOutput<typeof transformedSchema>) =>
+  Effect.gen(function* () {
+    const loader = yield* JobDetailLoader;
+    yield* loader.load(data);
+    return void 0;
+  });


### PR DESCRIPTION
## 概要

`headless-crawler` にJobDetailLoaderの基盤実装を追加しました。  
本実装は、今後予定しているETL（Extract, Transform, Load）構成への移行を見据えた前段階の整備です。

## 主な変更点

- JobDetailLoaderのDIコンテキスト・Layer・API呼び出しロジックを新規追加
- `InsertJobError` 型の定義
- ジョブストアAPIクライアント（`buildJobStoreClient`）の実装
- `buildProgram` 関数の追加（JobDetailLoader経由でデータ登録処理を実行）

## 背景・目的

将来的にETLパイプラインとして拡張するための基礎インフラを整備し、データフローの分離・拡張性を高めることを目的としています。

## 影響範囲

- `apps/headless-crawler/lib/L-jobDetail/` 配下に新規ファイルを追加
- 既存機能への影響はありません

## 補足

- 実際のAPIエンドポイントや認証情報は環境変数で管理
- 今後、ETL構成への発展やエラー型・ロジックの拡張を予定