### PR TITLE
feat(job-store-api): insert系APIのエラースキーマ・ハンドリングを整理

### DIFF
--- a/apps/job-store-api/src/routes/api/v1/jobs/error.ts
+++ b/apps/job-store-api/src/routes/api/v1/jobs/error.ts
@@ -11,3 +11,18 @@ export const createFetchValidationError = (
   message,
   errorType: "client",
 });
+
+
+export type UnexpectedError ={
+  readonly _tag: "UnexpectedError";
+  readonly message: string;
+  readonly errorType: "server";
+}
+
+export const createUnexpectedError = (
+  message: string,
+): UnexpectedError => ({
+  _tag: "UnexpectedError",
+  message,
+  errorType: "server",
+});

--- a/packages/models/src/job-store-api/endpoints/jobInsert.ts
+++ b/packages/models/src/job-store-api/endpoints/jobInsert.ts
@@ -11,7 +11,11 @@ export const insertJobSuccessResponseSchema = object({
   }),
 });
 
-export const insertJobClientErrorResponseSchema = object({
+export const insertJobDuplicationErrorResponseSchema = object({
+  message: string(),
+});
+
+export const insertJobGeneralClientErrorResponseSchema = object({
   message: string(),
 });
 


### PR DESCRIPTION
- insertJobのエラーレスポンススキーマを重複・一般・サーバー用に分離
- jobNumber重複時は409で返却するよう修正
- 予期しないエラー型（UnexpectedError）を追加
- テストに重複時409返却のケースを追加
- 型定義・エラーハンドリングの明確化