### PR TITLE
refactor(hello-work-job-searcher): APIルートパスをシンプルに変更

### DIFF
--- a/apps/hello-work-job-searcher/src/app/api/[[...route]]/route.ts
+++ b/apps/hello-work-job-searcher/src/app/api/[[...route]]/route.ts
@@ -72,8 +72,8 @@ const jobsContinueApp = new Hono().get("/", async (c) => {
 });
 
 const routes = app
-  .route("/proxy/job-store/jobs", jobsApp)
-  .route("/proxy/job-store/jobs/continue", jobsContinueApp);
+  .route("/jobs", jobsApp)
+  .route("/jobs/continue", jobsContinueApp);
 
 export type AppType = typeof routes;
 

--- a/apps/hello-work-job-searcher/src/app/components/client/atom/index.ts
+++ b/apps/hello-work-job-searcher/src/app/components/client/atom/index.ts
@@ -52,7 +52,7 @@ export const initializeJobListWriterAtom = atom<
   [SearchFilter],
   Promise<void>
 >(null, async (_, set, searchFilter) => {
-  const res = await client.api.proxy["job-store"].jobs.$get({
+  const res = await client.api.jobs.$get({
     query: {
       ...searchFilter,
     },
@@ -79,7 +79,7 @@ export const continuousJobOverviewListWriterAtom = atom<
   [string],
   Promise<void>
 >(null, async (_get, set, nextToken) => {
-  const res = await client.api.proxy["job-store"].jobs.continue.$get({
+  const res = await client.api.jobs.continue.$get({
     query: { nextToken },
   });
   const data = await res.json();

--- a/apps/hello-work-job-searcher/tests/index.spec.ts
+++ b/apps/hello-work-job-searcher/tests/index.spec.ts
@@ -6,7 +6,7 @@ test.describe("/api/proxy/job-store/jobs", () => {
     request,
   }) => {
     const res = await request.get(
-      "/api/proxy/job-store/jobs?employeeCountGt=abc",
+      "/api/jobs?employeeCountGt=abc",
     );
     expect(res.status()).toBe(500);
     const json = await res.json();
@@ -17,7 +17,7 @@ test.describe("/api/proxy/job-store/jobs", () => {
     request,
   }) => {
     const res = await request.get(
-      "/api/proxy/job-store/jobs?employeeCountLt=xyz",
+      "/api/jobs?employeeCountLt=xyz",
     );
     expect(res.status()).toBe(500);
     const json = await res.json();
@@ -28,7 +28,7 @@ test.describe("/api/proxy/job-store/jobs", () => {
     request,
   }) => {
     const res = await request.get(
-      "/api/proxy/job-store/jobs?employeeCountGt=-1",
+      "/api/jobs?employeeCountGt=-1",
     );
     expect(res.status()).toBe(500);
     const json = await res.json();
@@ -39,7 +39,7 @@ test.describe("/api/proxy/job-store/jobs", () => {
     request,
   }) => {
     const res = await request.get(
-      "/api/proxy/job-store/jobs?employeeCountLt=-1",
+      "/api/jobs?employeeCountLt=-1",
     );
     expect(res.status()).toBe(500);
     const json = await res.json();
@@ -47,10 +47,9 @@ test.describe("/api/proxy/job-store/jobs", () => {
   });
 });
 
-// /api/proxy/job-store/jobs/continue GET: nextToken異常系
-test.describe("/api/proxy/job-store/jobs/continue", () => {
+test.describe("/api/jobs/continue", () => {
   test("should return 400 if nextToken is missing", async ({ request }) => {
-    const res = await request.get("/api/proxy/job-store/jobs/continue");
+    const res = await request.get("/api/jobs/continue");
     expect(res.status()).toBe(400);
     const json = await res.json();
     expect(json).toEqual({ message: "Missing nextToken", success: false });
@@ -58,7 +57,7 @@ test.describe("/api/proxy/job-store/jobs/continue", () => {
 
   test("should return 500 if nextToken is invalid", async ({ request }) => {
     const res = await request.get(
-      "/api/proxy/job-store/jobs/continue?nextToken=invalidtoken",
+      "/api/jobs/continue?nextToken=invalidtoken",
     );
     expect([400, 500]).toContain(res.status());
     const json = await res.json();

--- a/apps/hello-work-job-searcher/tests/index.spec.ts
+++ b/apps/hello-work-job-searcher/tests/index.spec.ts
@@ -5,9 +5,7 @@ test.describe("/api/proxy/job-store/jobs", () => {
   test("should return 500 for invalid employeeCountGt (not a number)", async ({
     request,
   }) => {
-    const res = await request.get(
-      "/api/jobs?employeeCountGt=abc",
-    );
+    const res = await request.get("/api/jobs?employeeCountGt=abc");
     expect(res.status()).toBe(500);
     const json = await res.json();
     expect(json).toEqual({ message: "internal server error", success: false });
@@ -16,9 +14,7 @@ test.describe("/api/proxy/job-store/jobs", () => {
   test("should return 500 for invalid employeeCountLt (not a number)", async ({
     request,
   }) => {
-    const res = await request.get(
-      "/api/jobs?employeeCountLt=xyz",
-    );
+    const res = await request.get("/api/jobs?employeeCountLt=xyz");
     expect(res.status()).toBe(500);
     const json = await res.json();
     expect(json).toEqual({ message: "internal server error", success: false });
@@ -27,9 +23,7 @@ test.describe("/api/proxy/job-store/jobs", () => {
   test("should return 500 for negative employeeCountGt", async ({
     request,
   }) => {
-    const res = await request.get(
-      "/api/jobs?employeeCountGt=-1",
-    );
+    const res = await request.get("/api/jobs?employeeCountGt=-1");
     expect(res.status()).toBe(500);
     const json = await res.json();
     expect(json).toEqual({ message: "internal server error", success: false });
@@ -38,9 +32,7 @@ test.describe("/api/proxy/job-store/jobs", () => {
   test("should return 500 for negative employeeCountLt", async ({
     request,
   }) => {
-    const res = await request.get(
-      "/api/jobs?employeeCountLt=-1",
-    );
+    const res = await request.get("/api/jobs?employeeCountLt=-1");
     expect(res.status()).toBe(500);
     const json = await res.json();
     expect(json).toEqual({ message: "internal server error", success: false });
@@ -56,9 +48,7 @@ test.describe("/api/jobs/continue", () => {
   });
 
   test("should return 500 if nextToken is invalid", async ({ request }) => {
-    const res = await request.get(
-      "/api/jobs/continue?nextToken=invalidtoken",
-    );
+    const res = await request.get("/api/jobs/continue?nextToken=invalidtoken");
     expect([400, 500]).toContain(res.status());
     const json = await res.json();
     expect(json).toEqual({ message: "internal server error", success: false });


### PR DESCRIPTION
## 概要

- hello-work-job-searcherアプリのAPIルートパスを `/proxy/job-store/jobs` から `/jobs` へ、`/proxy/job-store/jobs/continue` から `/jobs/continue` へとシンプルに変更しました。
- これに伴い、テストコード内のリクエストパスもすべて新ルートに修正しました。

## 主な変更点

- APIルートのパスを短く・分かりやすくリファクタ
- テストコードのリクエストパスも新ルートに統一

## 動機・背景

- 叩く側（クライアント）がproxy構成を意識せずに済むようにするため
- APIの利用者・開発者双方にとって分かりやすいルーティング構成にするため
- 今後の保守性・拡張性向上のため

## 動作確認

- `pnpm test` でテストが正常に通ることを確認済み