### PR TITLE
refactor(hello-work-job-searcher): JobOverviewListの状態初期化と表示ロジックを分離

### DIFF
--- a/apps/hello-work-job-searcher/src/app/components/client/JobOverViewList/index.tsx
+++ b/apps/hello-work-job-searcher/src/app/components/client/JobOverViewList/index.tsx
@@ -24,17 +24,7 @@ function NewBadge() {
     </span>
   );
 }
-
-export function JobOverviewList({
-  initialDataFromServer,
-}: {
-  initialDataFromServer: {
-    jobs: JobList;
-    nextToken: string | undefined;
-    totalCount: number;
-  };
-}) {
-  useHydrateAtoms([[jobListAtom, initialDataFromServer]]);
+export function JobOverviewList() {
   const { items, nextToken } = useAtomValue(JobOverviewListAtom);
   const wrappedItems = useJobsWithFavorite(items);
   const fetchNextPage = useSetAtom(continuousJobOverviewListWriterAtom);
@@ -89,7 +79,7 @@ export function JobOverviewList({
           const isNew =
             !!item.receivedDate &&
             Date.now() - new Date(item.receivedDate).getTime() <=
-              3 * 24 * 60 * 60 * 1000;
+            3 * 24 * 60 * 60 * 1000;
           return (
             <div
               key={item.jobNumber}
@@ -130,4 +120,17 @@ export function JobOverviewList({
       </div>
     </div>
   );
+}
+
+export function HydratedJobOverviewList({
+  initialDataFromServer,
+}: {
+  initialDataFromServer: {
+    jobs: JobList;
+    nextToken: string | undefined;
+    totalCount: number;
+  };
+}) {
+  useHydrateAtoms([[jobListAtom, initialDataFromServer]]);
+  return <JobOverviewList />;
 }

--- a/apps/hello-work-job-searcher/src/app/components/client/JobOverViewList/index.tsx
+++ b/apps/hello-work-job-searcher/src/app/components/client/JobOverViewList/index.tsx
@@ -79,7 +79,7 @@ export function JobOverviewList() {
           const isNew =
             !!item.receivedDate &&
             Date.now() - new Date(item.receivedDate).getTime() <=
-            3 * 24 * 60 * 60 * 1000;
+              3 * 24 * 60 * 60 * 1000;
           return (
             <div
               key={item.jobNumber}

--- a/apps/hello-work-job-searcher/src/app/jobs/page.tsx
+++ b/apps/hello-work-job-searcher/src/app/jobs/page.tsx
@@ -1,7 +1,7 @@
 export const dynamic = "force-dynamic";
 
 import { Accordion } from "../components/client/Accordion";
-import { JobOverviewList } from "../components/client/JobOverViewList";
+import { HydratedJobOverviewList, JobOverviewList } from "../components/client/JobOverViewList";
 import { JobsSearchfilter } from "../components/client/JobsSearchfilter/index";
 import { JobtotalCount } from "../components/client/JobTotalCount";
 import { jobStoreClientOnServer } from "../store/server";
@@ -27,7 +27,7 @@ export default async function Page() {
           </Accordion>
         </div>
         <div className={styles.listSection}>
-          <JobOverviewList
+          <HydratedJobOverviewList
             initialDataFromServer={{
               jobs: data.jobs,
               nextToken: data.nextToken,

--- a/apps/hello-work-job-searcher/src/app/jobs/page.tsx
+++ b/apps/hello-work-job-searcher/src/app/jobs/page.tsx
@@ -1,7 +1,10 @@
 export const dynamic = "force-dynamic";
 
 import { Accordion } from "../components/client/Accordion";
-import { HydratedJobOverviewList, JobOverviewList } from "../components/client/JobOverViewList";
+import {
+  HydratedJobOverviewList,
+  JobOverviewList,
+} from "../components/client/JobOverViewList";
 import { JobsSearchfilter } from "../components/client/JobsSearchfilter/index";
 import { JobtotalCount } from "../components/client/JobTotalCount";
 import { jobStoreClientOnServer } from "../store/server";


### PR DESCRIPTION
## 概要

- JobOverviewListコンポーネントの責務を分離し、状態初期化（useHydrateAtoms）をHydratedJobOverviewListに切り出しました。
- JobOverviewListは純粋な表示用コンポーネントとなり、サーバー側ではHydratedJobOverviewListを利用する形に変更しました。

## 主な変更点

- useHydrateAtomsによる初期化処理をHydratedJobOverviewListに分離
- JobOverviewListはpropsなしの表示専用に
- page.tsxでHydratedJobOverviewListを利用するよう修正

## 動機・背景

- 状態初期化と表示ロジックの責務を明確に分離し、可読性・保守性を向上させるため
- 今後の機能追加やテスト容易性の向上

## 動作確認

- テストコードでは