### PR TITLE
refactor(hello-work-job-searcher): searchレイアウト用CSS・クラス名の整理

### DIFF
--- a/apps/hello-work-job-searcher/src/app/jobs/page.module.css
+++ b/apps/hello-work-job-searcher/src/app/jobs/page.module.css
@@ -2,7 +2,7 @@
   height: 100%;
 }
 
-.layoutContainer {
+.searchLayoutContainer {
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -11,13 +11,13 @@
 
 
 
-.headerSection {
+.searchLayoutHeaderSection {
   min-height: 0;
 }
 
 
 
-.listSection {
+.searchLayoutListSection {
   min-height: 0;
   flex: 1;
 }

--- a/apps/hello-work-job-searcher/src/app/jobs/page.tsx
+++ b/apps/hello-work-job-searcher/src/app/jobs/page.tsx
@@ -20,16 +20,16 @@ export default async function Page() {
   }
   const data = result.value;
   return (
-    <main className={styles.mainSection}>
-      <div className={styles.layoutContainer}>
-        <div className={styles.headerSection}>
+    <div className={styles.mainSection}>
+      <div className={styles.searchLayoutContainer}>
+        <div className={styles.searchLayoutHeaderSection}>
           <h1>求人情報一覧</h1>
           <JobtotalCount initialDataFromServer={data.meta.totalCount} />
           <Accordion title="絞り込み">
             <JobsSearchfilter />
           </Accordion>
         </div>
-        <div className={styles.listSection}>
+        <div className={styles.searchLayoutListSection}>
           <HydratedJobOverviewList
             initialDataFromServer={{
               jobs: data.jobs,
@@ -39,6 +39,6 @@ export default async function Page() {
           />
         </div>
       </div>
-    </main>
+    </div>
   );
 }


### PR DESCRIPTION
## 概要

- `/jobs` ページのレイアウト・セクション用CSSクラス名を整理し、今後の2カラム構成（左：検索＋一覧、右：求人詳細）に備えた前処理的なリファクタを実施しました。

## 主な変更点

- `layoutContainer`, `headerSection`, `listSection` を `searchLayout*` 系のクラス名にリネーム
- JSX側も新しいクラス名に統一
- レイアウト・セクションの役割が明確になり、今後の2カラム化対応が容易に

## 動機・背景

- `/jobs` ページを「左：検索＋一覧／右：求人詳細」レイアウトに拡張するための準備
- クラス名の一貫性を高め、保守性・拡張性を向上させるため

## 動作確認

- `pnpm dev` で画面レイアウトが崩れないことを手動で確認済み