### PR TITLE
fix(job-store-api): JWTのverifyを導入しnextTokenの署名検証を強化

### DIFF
--- a/apps/job-store-api/src/routes/api/v1/jobs/continue/error.ts
+++ b/apps/job-store-api/src/routes/api/v1/jobs/continue/error.ts
@@ -13,10 +13,20 @@ export type DecodeJWTPayloadError = {
   readonly message: string;
 };
 
+export type JWTVerificationError = {
+  readonly _tag: "JWTVerificationError";
+  readonly message: string;
+};
+
 // エラー型定義
 // エラーファクトリ関数
 export const createJWTDecodeError = (message: string): JWTDecodeError => ({
   _tag: "JWTDecodeError",
+  message,
+});
+
+export const createJWTVerificationError = (message: string): JWTVerificationError => ({
+  _tag: "JWTVerificationError",
   message,
 });
 

--- a/apps/job-store-api/src/routes/api/v1/jobs/continue/index.ts
+++ b/apps/job-store-api/src/routes/api/v1/jobs/continue/index.ts
@@ -12,7 +12,7 @@ import {
 import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
-import { decode, sign } from "hono/jwt";
+import { decode, sign, verify } from "hono/jwt";
 import { describeRoute, resolver } from "hono-openapi";
 import { err, ok, okAsync, ResultAsync, safeTry } from "neverthrow";
 import * as v from "valibot";
@@ -22,6 +22,7 @@ import {
   createDecodeJWTPayloadError,
   createJWTDecodeError,
   createJWTExpiredError,
+  createJWTVerificationError,
 } from "./error";
 import { createJobStoreDBClientAdapter } from "../../../../../adapters";
 import {
@@ -81,10 +82,7 @@ app.get(
         return ok(result.output);
       })();
       const decodeResult = yield* ResultAsync.fromPromise(
-        Promise.resolve(decode(nextToken)),
-        (error) =>
-          createJWTDecodeError(`JWT decoding failed.\n${String(error)}`),
-      );
+        verify(nextToken, jwtSecret), (error) => createJWTVerificationError(`JWT verification failed.\n${error instanceof Error ? error.message : String(error)}`));
 
       const payloadValidation = v.safeParse(
         decodedNextTokenSchema,
@@ -146,6 +144,9 @@ app.get(
         if (restJobCount <= limit) return okAsync(undefined);
         const validPayload: DecodedNextToken = {
           exp: Math.floor(Date.now() / 1000) + 60 * 15, // 15分後の有効期限
+          iss: "sho-hello-work-job-searcher",
+          iat: Date.now(),
+          nbf: Date.now(),
           cursor: { jobId, receivedDateByISOString },
           filter: meta.filter,
         };
@@ -165,7 +166,7 @@ app.get(
         console.error(error);
 
         switch (error._tag) {
-          case "JWTDecodeError":
+          case "JWTVerificationError":
             throw new HTTPException(400, { message: "invalid nextToken" });
           case "JWTSignatureError":
           case "EnvError":

--- a/apps/job-store-api/src/routes/api/v1/jobs/index.ts
+++ b/apps/job-store-api/src/routes/api/v1/jobs/index.ts
@@ -348,6 +348,9 @@ app.get("/", jobListRoute, vValidator("query", jobListQuerySchema), (c) => {
       if (restJobCount <= limit) return okAsync(undefined);
       const validPayload: DecodedNextToken = {
         exp: Math.floor(Date.now() / 1000) + 60 * 15, // 15分後の有効期限
+        iss: "sho-hello-work-job-searcher",
+        iat: Date.now(),
+        nbf: Date.now(),
         cursor: { jobId, receivedDateByISOString },
         filter: meta.filter,
       };

--- a/packages/models/src/job-store-api/endpoints/jobListContinue.ts
+++ b/packages/models/src/job-store-api/endpoints/jobListContinue.ts
@@ -11,6 +11,9 @@ export const cursorSchema = object({
 });
 
 export const decodedNextTokenSchema = object({
+  iss: string(),
+  iat: number(),
+  nbf: number(),
   exp: number(),
   cursor: cursorSchema,
   filter: searchFilterSchema,


### PR DESCRIPTION
- JWTのdecodeからverifyに変更し、署名検証を追加
- JWTVerificationError型・エラーハンドリングを追加
- nextTokenのpayloadにiss/iat/nbfを追加しスキーマも更新
- セキュリティ上の脆弱性を修正