### PR TITLE
chore(headless-crawler): job insert時のエラー詳細出力を強化

### DIFF
--- a/apps/headless-crawler/functions/E-T-L-JobDetailHandler/helper.ts
+++ b/apps/headless-crawler/functions/E-T-L-JobDetailHandler/helper.ts
@@ -188,11 +188,6 @@ export function buildJobStoreClient() {
                 message: `insert job response failed.\n${String(e)}`,
               }),
           });
-          if (!res.ok) {
-            throw new InsertJobError({
-              message: `insert job failed.\nstatus=${res.status}\nstatusText=${res.statusText}`,
-            });
-          }
           const data = yield* Effect.tryPromise({
             try: () => res.json(),
             catch: (e) =>
@@ -200,6 +195,11 @@ export function buildJobStoreClient() {
                 message: `insert job transforming json failed.\n${String(e)}`,
               }),
           });
+          if (!res.ok) {
+            throw new InsertJobError({
+              message: `insert job failed.\nstatus=${res.status}\nstatusText=${res.statusText}\nmessage=${JSON.stringify(data, null, 2)}`,
+            });
+          }
           yield* Effect.logDebug(
             `response data. ${JSON.stringify(data, null, 2)}`,
           );


### PR DESCRIPTION
## 概要

headless-crawlerのジョブ登録API呼び出し時、エラー発生時の出力内容を強化しました。

## 変更内容

- ジョブinsert時にAPIエラーが発生した場合、従来のstatusやstatusTextに加え、レスポンスbodyもエラーメッセージに含めて出力するよう改善
- これにより、障害発生時やデバッグ時に原因特定がしやすくなります

## 背景・目的

これまでジョブ登録APIでエラーが発生した際、レスポンスbodyの内容が出力されず、詳細な原因調査が困難でした。  
今回の対応により、API側から返却されるエラー詳細も確認できるようになり、運用・保守性が向上します。

## 補足

- 機能追加や仕様変更はありません（内部的な出力強化のみ）
- 既存の正常系フローには影響ありません