### PR TITLE
chore(headless-crawler): insert job時のエラー詳細出力を強化

### DIFF
--- a/apps/headless-crawler/lib/jobDetail/loader/helper.ts
+++ b/apps/headless-crawler/lib/jobDetail/loader/helper.ts
@@ -26,11 +26,6 @@ export function buildJobStoreClient() {
                 message: `insert job response failed.\n${e instanceof Error ? e.message : String(e)}`,
               }),
           });
-          if (!res.ok) {
-            throw new InsertJobError({
-              message: `insert job failed.\nstatus=${res.status}\nstatusText=${res.statusText}`,
-            });
-          }
           const data = yield* Effect.tryPromise({
             try: () => res.json(),
             catch: (e) =>
@@ -38,6 +33,12 @@ export function buildJobStoreClient() {
                 message: `insert job transforming json failed.\n${e instanceof Error ? e.message : String(e)}`,
               }),
           });
+          if (!res.ok) {
+            throw new InsertJobError({
+              message: `insert job failed.\nstatus=${res.status}\nstatusText=${res.statusText}\nmessage=${JSON.stringify(data, null, 2)}`,
+            });
+          }
+
           yield* Effect.logDebug(
             `response data. ${JSON.stringify(data, null, 2)}`,
           );


### PR DESCRIPTION
## 概要

#413 の対応時に漏れていた、insert job時のエラー詳細出力強化の修正を追加しました。

## 変更内容

- insert job APIエラー時に、status/statusText/レスポンスbodyを正しく出力するよう再修正

## 背景

#413 の修正で一部対応漏れがあったため、改めて不足分を補完しました。

## 補足

- 既存の正常系フローには影響ありません
- 内部的な出力強化のみです