### PR TITLE
fix(headless-crawler): homePageのバリデーション・変換・型定義を整理

### DIFF
--- a/apps/headless-crawler/functions/E-T-L-JobDetailHandler/helper.ts
+++ b/apps/headless-crawler/functions/E-T-L-JobDetailHandler/helper.ts
@@ -28,6 +28,7 @@ import type { TtoFirstRecord } from "./type";
 import { fromExtractJobNumberHandlerJobQueueEventBodySchema } from "./schema";
 import type { SQSRecord } from "aws-lambda";
 import { issueToLogString } from "../../lib/core/util";
+import { toTransformedHomePage } from "../../lib/jobDetail/transformer/helper";
 
 const safeParseFromExtractJobNumberJobQueueEventBodySchema = (val: unknown) => {
   const result = v.safeParse(
@@ -90,7 +91,7 @@ export const job2InsertedJob = (job: extractedJob) => {
     employmentType,
     expiryDate: rawExpiryDate,
     receivedDate: rawReceivedDate,
-    homePage,
+    homePage: rawHomePage,
     wage: rawWage,
     workingHours: rawWorkingHours,
     occupation,
@@ -133,6 +134,7 @@ export const job2InsertedJob = (job: extractedJob) => {
           message: `parse working hours failed.\n${String(e)}`,
         }),
     });
+    const homePage = rawHomePage ? yield* toTransformedHomePage(rawHomePage) : undefined;
     return {
       jobNumber,
       companyName,

--- a/apps/headless-crawler/lib/jobDetail/helpers/extractors/index.ts
+++ b/apps/headless-crawler/lib/jobDetail/helpers/extractors/index.ts
@@ -22,7 +22,7 @@ import {
   validateEmployeeCount,
   validateEmploymentType,
   validateExpiryDate,
-  validateHomePage,
+  validateRawHomePage,
   validateJobDescription,
   validateOccupation,
   validateQualification,
@@ -31,7 +31,7 @@ import {
   validateWorkingHours,
   validateWorkPlace,
 } from "../validators";
-import type { JobDetailPropertyValidationError } from "../validators/error";
+import type { JobDetailPropertyValidationError, RawHomePageValidationError } from "../validators/error";
 import { homePageElmExists, qualificationsElmExists } from "../checkers";
 import type {
   HomePageElmNotFoundError,
@@ -68,11 +68,11 @@ function extractCompanyName(page: JobDetailPage) {
       catch: (e) =>
         e instanceof v.ValiError
           ? new ExtractJobCompanyNameError({
-              message: e.message,
-            })
+            message: e.message,
+          })
           : new ExtractJobCompanyNameError({
-              message: `unexpected error.\n${String(e)}`,
-            }),
+            message: `unexpected error.\n${String(e)}`,
+          }),
     });
     yield* Effect.logDebug(`rawCompanyName=${rawCompanyName}`);
     const companyName = yield* validateCompanyName(rawCompanyName);
@@ -138,7 +138,7 @@ function extractHomePage(page: JobDetailPage) {
         }),
     });
     yield* Effect.logDebug(`rawHomePage=${rawHomePage}`);
-    const homePage = yield* validateHomePage(rawHomePage?.trim());
+    const homePage = yield* validateRawHomePage(rawHomePage?.trim());
     yield* Effect.logDebug(`homePage=${homePage}`);
     return homePage;
   });
@@ -308,6 +308,7 @@ export function extractJobInfo(
   | JobDetailPropertyValidationError
   | HomePageElmNotFoundError
   | QualificationsElmNotFoundError
+  | RawHomePageValidationError
 > {
   return Effect.gen(function* () {
     yield* Effect.logDebug("Starting to extract job info from JobDetailPage");

--- a/apps/headless-crawler/lib/jobDetail/helpers/validators/error.ts
+++ b/apps/headless-crawler/lib/jobDetail/helpers/validators/error.ts
@@ -2,73 +2,78 @@ import { Data } from "effect";
 
 export class JobDetailPageValidationError extends Data.TaggedError(
   "JobDetailPageValidationError",
-)<{ readonly message: string }> {}
+)<{ readonly message: string }> { }
 
 export class JobNumberValidationError extends Data.TaggedError(
   "JobNumberValidationError",
 )<{
   readonly message: string;
-}> {}
+}> { }
 export class CompanyNameValidationError extends Data.TaggedError(
   "CompanyNameValidationError",
 )<{
   readonly message: string;
-}> {}
+}> { }
 export class ReceivedDateValidationError extends Data.TaggedError(
   "ReceivedDateValidationError",
 )<{
   readonly message: string;
-}> {}
+}> { }
 export class ExpiryDateValidationError extends Data.TaggedError(
   "ExpiryDateValidationError",
 )<{
   readonly message: string;
-}> {}
+}> { }
+export class RawHomePageValidationError extends Data.TaggedError(
+  "RawHomePageValidationError",
+)<{
+  readonly message: string;
+}> { }
 export class HomePageValidationError extends Data.TaggedError(
   "HomePageValidationError",
 )<{
   readonly message: string;
-}> {}
+}> { }
 export class OccupationValidationError extends Data.TaggedError(
   "OccupationValidationError",
 )<{
   readonly message: string;
-}> {}
+}> { }
 export class EmploymentTypeValidationError extends Data.TaggedError(
   "EmploymentTypeValidationError",
 )<{
   readonly message: string;
-}> {}
+}> { }
 export class WageValidationError extends Data.TaggedError(
   "WageValidationError",
 )<{
   readonly message: string;
-}> {}
+}> { }
 export class WorkingHoursValidationError extends Data.TaggedError(
   "WageValidationError",
 )<{
   readonly message: string;
-}> {}
+}> { }
 export class EmployeeCountValidationError extends Data.TaggedError(
   "EmployeeCountValidationError",
 )<{
   readonly message: string;
-}> {}
+}> { }
 export class WorkPlaceValidationError extends Data.TaggedError(
   "WorkPlaceValidationError",
 )<{
   readonly message: string;
-}> {}
+}> { }
 export class JobDescriptionValidationError extends Data.TaggedError(
   "JobDescriptionValidationError",
 )<{
   readonly message: string;
-}> {}
+}> { }
 export class QualificationValidationError extends Data.TaggedError(
   "QualificationValidationError",
 )<{
   readonly message: string;
-}> {}
+}> { }
 
 export type JobDetailPropertyValidationError =
   | JobNumberValidationError

--- a/apps/headless-crawler/lib/jobDetail/helpers/validators/index.ts
+++ b/apps/headless-crawler/lib/jobDetail/helpers/validators/index.ts
@@ -8,11 +8,11 @@ import {
   RawWorkingHoursSchema,
   companyNameSchema,
   employmentTypeSchema,
-  homePageSchema,
   jobDescriptionSchema,
   jobNumberSchema,
   occupationSchema,
   qualificationsSchema,
+  rawHomePageSchema,
   workPlaceSchema,
 } from "@sho/models";
 import { Effect } from "effect";
@@ -23,11 +23,11 @@ import {
   EmployeeCountValidationError,
   EmploymentTypeValidationError,
   ExpiryDateValidationError,
-  HomePageValidationError,
   JobDescriptionValidationError,
   JobDetailPageValidationError,
   OccupationValidationError,
   QualificationValidationError,
+  RawHomePageValidationError,
   ReceivedDateValidationError,
   WageValidationError,
   WorkingHoursValidationError,
@@ -93,12 +93,12 @@ export function validateExpiryDate(val: unknown) {
     return yield* Effect.succeed(result.output);
   });
 }
-export function validateHomePage(val: unknown) {
+export function validateRawHomePage(val: unknown) {
   return Effect.gen(function* () {
-    const result = v.safeParse(homePageSchema, val);
+    const result = v.safeParse(rawHomePageSchema, val);
     if (!result.success) {
       return yield* Effect.fail(
-        new HomePageValidationError({
+        new RawHomePageValidationError({
           message: `parse error. detail: ${result.issues.map(issueToLogString).join("\n")}`,
         }),
       ).pipe(
@@ -149,8 +149,8 @@ export function validateEmploymentType(val: unknown) {
       e instanceof v.ValiError
         ? new EmploymentTypeValidationError({ message: e.message })
         : new EmploymentTypeValidationError({
-            message: `unexpected error.\n${String(e)}`,
-          }),
+          message: `unexpected error.\n${String(e)}`,
+        }),
   });
 }
 
@@ -164,11 +164,11 @@ export function validateWage(val: unknown) {
       catch: (e) =>
         e instanceof v.ValiError
           ? new WageValidationError({
-              message: `parse failed. detail: ${e.issues.map(issueToLogString).join("\n")}`,
-            })
+            message: `parse failed. detail: ${e.issues.map(issueToLogString).join("\n")}`,
+          })
           : new WageValidationError({
-              message: `unexpected error.\n${String(e)}`,
-            }),
+            message: `unexpected error.\n${String(e)}`,
+          }),
     }).pipe(
       Effect.tap((wage) => {
         return Effect.logDebug(
@@ -185,11 +185,11 @@ export function validateWorkingHours(val: unknown) {
     catch: (e) =>
       e instanceof v.ValiError
         ? new WorkingHoursValidationError({
-            message: `parse failed. detail: ${e.issues.map(issueToLogString).join("\n")}`,
-          })
+          message: `parse failed. detail: ${e.issues.map(issueToLogString).join("\n")}`,
+        })
         : new WorkingHoursValidationError({
-            message: `unexpected error.\n${String(e)}`,
-          }),
+          message: `unexpected error.\n${String(e)}`,
+        }),
   }).pipe(
     Effect.tap((workingHours) => {
       return Effect.logDebug(
@@ -204,11 +204,11 @@ export function validateEmployeeCount(val: unknown) {
     catch: (e) =>
       e instanceof v.ValiError
         ? new EmployeeCountValidationError({
-            message: `parse failed. detail: ${e.issues.map(issueToLogString).join("\n")}`,
-          })
+          message: `parse failed. detail: ${e.issues.map(issueToLogString).join("\n")}`,
+        })
         : new EmployeeCountValidationError({
-            message: `unexpected error.\n${String(e)}`,
-          }),
+          message: `unexpected error.\n${String(e)}`,
+        }),
   }).pipe(
     Effect.tap((employeeCount) => {
       return Effect.logDebug(
@@ -224,11 +224,11 @@ export function validateWorkPlace(val: unknown) {
     catch: (e) =>
       e instanceof v.ValiError
         ? new WorkPlaceValidationError({
-            message: `parse failed. detail: ${e.issues.map(issueToLogString).join("\n")}`,
-          })
+          message: `parse failed. detail: ${e.issues.map(issueToLogString).join("\n")}`,
+        })
         : new WorkPlaceValidationError({
-            message: `unexpected error. \n${String(e)}`,
-          }),
+          message: `unexpected error. \n${String(e)}`,
+        }),
   }).pipe(
     Effect.tap((workPlace) => {
       return Effect.logDebug(
@@ -244,11 +244,11 @@ export function validateJobDescription(val: unknown) {
     catch: (e) =>
       e instanceof v.ValiError
         ? new JobDescriptionValidationError({
-            message: `parse failed. detail: ${e.issues.map(issueToLogString).join("\n")}`,
-          })
+          message: `parse failed. detail: ${e.issues.map(issueToLogString).join("\n")}`,
+        })
         : new JobDescriptionValidationError({
-            message: `unexpected error.\n${String}`,
-          }),
+          message: `unexpected error.\n${String}`,
+        }),
   }).pipe(
     Effect.tap((jobDescription) => {
       return Effect.logDebug(

--- a/apps/headless-crawler/lib/jobDetail/transformer/context.ts
+++ b/apps/headless-crawler/lib/jobDetail/transformer/context.ts
@@ -25,7 +25,6 @@ import { parseHTML } from "linkedom";
 import {
   validateCompanyName,
   validateEmploymentType,
-  validateHomePage,
   validateJobDescription,
   validateOccupation,
   validateQualification,
@@ -33,11 +32,13 @@ import {
 } from "../helpers/validators";
 import {
   toTransformedEmployeeCount,
+  toTransformedHomePage,
   toTransformedWage,
   toTransformedWorkingHours,
 } from "./helper";
 import type {
   EmployeeCountTransformationError,
+  HomePageTransformationError,
   WageTransformationError,
   WorkingHoursTransformationError,
 } from "./error";
@@ -58,7 +59,7 @@ export class TransformerConfig extends Context.Tag("Config")<
       readonly logDebug: boolean;
     }>;
   }
->() {}
+>() { }
 
 export const transformerConfigLive = Layer.succeed(
   TransformerConfig,
@@ -94,11 +95,12 @@ export class JobDetailTransformer extends Context.Tag("JobDetailTransformer")<
       | WorkingHoursTransformationError
       | EmployeeCountTransformationError
       | ReceivedDateTransformationError
-      | ExpiryDateTransformationError,
+      | ExpiryDateTransformationError
+      | HomePageTransformationError,
       TransformerConfig
     >;
   }
->() {}
+>() { }
 
 export const transformerLive = Layer.effect(
   JobDetailTransformer,
@@ -127,8 +129,8 @@ export const transformerLive = Layer.effect(
           const expiryDate = yield* transformExpiryDate(rawExpiryDate);
           const rawHomePage = document.querySelector("#ID_hp")?.textContent;
           const homePage = rawHomePage
-            ? yield* validateHomePage(rawHomePage)
-            : null;
+            ? yield* toTransformedHomePage(rawHomePage)
+            : undefined;
           const rawOccupation = document.querySelector("#ID_sksu")?.textContent;
           const occupation = yield* validateOccupation(rawOccupation);
           const rawEmplomentType =
@@ -185,4 +187,4 @@ export const mainLive = transformerLive.pipe(
 
 class ScrapeJobDataError extends Data.TaggedError("ScrapeJobDataError")<{
   readonly message: string;
-}> {}
+}> { }

--- a/apps/headless-crawler/lib/jobDetail/transformer/error.ts
+++ b/apps/headless-crawler/lib/jobDetail/transformer/error.ts
@@ -11,3 +11,7 @@ export class WorkingHoursTransformationError extends Data.TaggedError(
 export class EmployeeCountTransformationError extends Data.TaggedError(
   "EmployeeCountTransformationError",
 )<{ readonly message: string }> {}
+
+export class HomePageTransformationError extends Data.TaggedError(
+  "HomePageTransformationError",
+)<{ readonly message: string }> {}

--- a/apps/headless-crawler/lib/jobDetail/transformer/helper.ts
+++ b/apps/headless-crawler/lib/jobDetail/transformer/helper.ts
@@ -1,5 +1,6 @@
 import {
   transformedEmployeeCountSchema,
+  transformedHomePageSchema,
   transformedWageSchema,
   transformedWorkingHoursSchema,
 } from "@sho/models";
@@ -7,6 +8,7 @@ import { Effect } from "effect";
 import { safeParse } from "valibot";
 import {
   EmployeeCountTransformationError,
+  HomePageTransformationError,
   WageTransformationError,
   WorkingHoursTransformationError,
 } from "./error";
@@ -47,3 +49,15 @@ export const toTransformedEmployeeCount = (val: unknown) => {
   }
   return Effect.succeed(result.output);
 };
+
+export const toTransformedHomePage = (val: unknown) => {
+  const result = safeParse(transformedHomePageSchema, val)
+  if (!result.success) {
+    return Effect.fail(
+      new HomePageTransformationError({
+        message: `HomePageの変換に失敗しました。detail: ${result.issues.map(issueToLogString).join("\n")}`,
+      }),
+    );
+  }
+  return Effect.succeed(result.output);
+}

--- a/packages/models/src/headless-crawler/jobDetail/extractor.ts
+++ b/packages/models/src/headless-crawler/jobDetail/extractor.ts
@@ -10,10 +10,9 @@ export const companyNameSchema = v.pipe(
   v.brand("companyName"),
 );
 
-export const homePageSchema = v.pipe(
+export const rawHomePageSchema = v.pipe(
   v.string(),
-  v.url("home page should be url"),
-  v.brand("homePage"),
+  v.brand("homePage(raw)"),
 );
 export const occupationSchema = v.pipe(
   v.string(),
@@ -82,7 +81,7 @@ export const extractedJobSchema = v.object({
   companyName: companyNameSchema,
   receivedDate: RawReceivedDateShema,
   expiryDate: RawExpiryDateSchema,
-  homePage: v.nullable(homePageSchema),
+  homePage: v.nullable(rawHomePageSchema),
   occupation: occupationSchema,
   employmentType: employmentTypeSchema,
   employeeCount: RawEmployeeCountSchema,

--- a/packages/models/src/headless-crawler/jobDetail/transformer.ts
+++ b/packages/models/src/headless-crawler/jobDetail/transformer.ts
@@ -3,6 +3,7 @@ import {
   extractedJobSchema,
   RawEmployeeCountSchema,
   RawExpiryDateSchema,
+  rawHomePageSchema,
   RawReceivedDateShema,
   RawWageSchema,
   RawWorkingHoursSchema,
@@ -101,8 +102,12 @@ export const transformedEmployeeCountSchema = v.pipe(
   v.brand("TransformedEmployeeCount"),
 );
 
+export const transformedHomePageSchema = v.pipe(rawHomePageSchema, v.transform((val) => val.trim()), v.url("home page should be url"), v.brand("homePage(transformed)"),);
+
+
 export const transformedSchema = v.object({
-  ...v.omit(extractedJobSchema, ["wage", "workingHours"]).entries,
+  ...v.omit(extractedJobSchema, ["wage", "workingHours", "homePage"]).entries,
+  homePage: v.optional(transformedHomePageSchema),
   wageMin: v.number(),
   wageMax: v.number(),
   workingStartTime: v.string(),

--- a/packages/models/src/headless-crawler/type.ts
+++ b/packages/models/src/headless-crawler/type.ts
@@ -1,6 +1,6 @@
 import type { Locator, Page } from "playwright";
 import type * as v from "valibot";
-import type { jobNumberSchema, extractedJobSchema } from "./jobDetail";
+import type { jobNumberSchema, extractedJobSchema, transformedSchema } from "./jobDetail";
 
 export type JobNumber = v.InferOutput<typeof jobNumberSchema>;
 
@@ -14,6 +14,8 @@ const jobDetailPage = Symbol();
 export type JobDetailPage = Page & { [jobDetailPage]: unknown };
 
 export type extractedJob = v.InferOutput<typeof extractedJobSchema>;
+
+export type TransformedJob = v.InferOutput<typeof transformedSchema>;
 
 const jobSearchPage = Symbol();
 


### PR DESCRIPTION
## 概要

homePageフィールドのバリデーション処理がどこかで正しく動作していない可能性があったため、認知モデルに近い形でバリデーション処理全体をリファクタリングしました。  
この対応により、homePageのバリデーション抜けや不整合が解消されているはずです。

## 変更内容

- homePageのraw/transformedスキーマ分離と責務分離
- バリデータ・トランスフォーマ層でのバリデーション/変換処理の明確化
- 型・エラー型の整理と一貫性向上

## 背景

どこかでhomePageのバリデーションが正しく機能していない現象があり、原因箇所の特定が困難だったため、  
全体的にバリデーション処理を整理・リファクタし、認知的に追いやすい構造にしました。  
この修正でhomePageのバリデーション抜け・不整合が解消されていることを期待しています。

## 補足

- 振る舞い・仕様自体の変更はありません（内部構造の整理のみ）
- 既存の正常系フローには影響ありません