### PR TITLE
chore(headless-crawler): rename and refactor verification scripts

### DIFF
--- a/apps/headless-crawler/package.json
+++ b/apps/headless-crawler/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "bootstrap": "aws-vault exec cdk-bootstrap-user -- cdk bootstrap  --cloudformation-execution-policies arn:aws:iam::aws:policy/AdministratorAccess",
     "deploy": "aws-vault exec cdk-deploy -- cdk deploy",
-    "verify:crawler": "ts-node lib/crawler/playground/index.ts",
-    "verify:scraper": "ts-node lib/scraper/playground/index.ts",
+    "verify:e-t-crawler": "ts-node lib/E-T-crawler/playground/index.ts",
+    "verify:job-detail-extractor": "ts-node lib/jobDetail/extractor/playground/index.ts",
     "verify:transform-jobDetail": "ts-node lib/T-jobDetail/playground/index.ts",
     "type-check": "pnpm exec tsc --noEmit"
   },


### PR DESCRIPTION
## 概要

headless-crawlerアプリの検証系スクリプトの命名を整理・リファクタリングしました。

## 主な変更点

- `package.json` 内の検証系スクリプト名をより明確なものにリネーム
  - `verify:crawler` → `verify:e-t-crawler`
  - `verify:scraper` → `verify:job-detail-extractor`
- スクリプトの役割が直感的に分かるように統一

## 背景・目的

スクリプト名の可読性・保守性向上のため、役割が分かりやすい命名に変更しました。今後の開発・運用時の混乱防止を目的としています。

## 動作確認

- 各検証スクリプトが正常に動作することを確認済み