### PR TITLE
feat(models): add jobNumber schema and types

### DIFF
--- a/packages/models/src/headless-crawler/index.ts
+++ b/packages/models/src/headless-crawler/index.ts
@@ -1,3 +1,3 @@
 export * from "./jobDetail";
-export * from "./jobNumber"
+export * from "./jobNumber";
 export * from "./type";

--- a/packages/models/src/headless-crawler/jobNumber/event.ts
+++ b/packages/models/src/headless-crawler/jobNumber/event.ts
@@ -1,6 +1,6 @@
-import * as v from "valibot"
-import { extendedConfigSchema } from "./extendedConfig"
+import * as v from "valibot";
+import { extendedConfigSchema } from "./extendedConfig";
 
 export const eventSchema = v.object({
-    extendedConfig: v.optional(extendedConfigSchema)
-})
+  extendedConfig: v.optional(extendedConfigSchema),
+});

--- a/packages/models/src/headless-crawler/jobNumber/extendedConfig.ts
+++ b/packages/models/src/headless-crawler/jobNumber/extendedConfig.ts
@@ -1,5 +1,5 @@
-import * as v from "valibot"
+import * as v from "valibot";
 
 export const extendedConfigSchema = v.object({
-    logDebug: v.boolean(),
-})
+  logDebug: v.boolean(),
+});

--- a/packages/models/src/headless-crawler/jobNumber/index.ts
+++ b/packages/models/src/headless-crawler/jobNumber/index.ts
@@ -1,2 +1,2 @@
-export * from "./event"
-export * from "./extendedConfig"
+export * from "./event";
+export * from "./extendedConfig";

--- a/packages/models/src/headless-crawler/type.ts
+++ b/packages/models/src/headless-crawler/type.ts
@@ -1,6 +1,10 @@
 import type { Locator, Page } from "playwright";
 import type * as v from "valibot";
-import type { jobNumberSchema, extractedJobSchema, transformedSchema } from "./jobDetail";
+import type {
+  jobNumberSchema,
+  extractedJobSchema,
+  transformedSchema,
+} from "./jobDetail";
 import type { eventSchema } from "./jobNumber";
 
 export type JobNumber = v.InferOutput<typeof jobNumberSchema>;


### PR DESCRIPTION
## 概要
jobNumber関連のスキーマ・型定義・エクスポートを追加しました。

## 主な変更点
- `jobNumber` ディレクトリを新規追加し、`eventSchema`・`extendedConfigSchema`を定義
- `JobNumberEvent`型を追加し、型定義を拡張
- `index.ts`・`type.ts`で新規型・スキーマをエクスポート

## 背景・目的
jobNumberに関する型安全なデータ構造を導入し、今後の開発・保守性向上を図るため。

## 今後の展望・意図
将来的にLambdaのeventからconfigを動的に注入・上書きできる仕組みを導入予定です。その布石として、今回jobNumber関連のスキーマ・型定義を拡張しました。これにより、event経由でconfigを柔軟に扱える基盤を整えています。

## 確認事項
- 型定義の追加による既存コードへの影響がないこと
- 新規スキーマ・型が正しくエクスポートされていること