### PR TITLE
feat(headless-crawler): JobNumberHandlerでevent経由のconfig注入・バリデーション対応

### DIFF
--- a/apps/headless-crawler/functions/ET-JobNumberHandler/error.ts
+++ b/apps/headless-crawler/functions/ET-JobNumberHandler/error.ts
@@ -1,0 +1,7 @@
+import { Data } from "effect";
+
+export class EventSchemaValidationError extends Data.TaggedError(
+    "EventSchemaValidationError",
+)<{
+    readonly message: string;
+}> { }

--- a/apps/headless-crawler/functions/ET-JobNumberHandler/handler.ts
+++ b/apps/headless-crawler/functions/ET-JobNumberHandler/handler.ts
@@ -1,25 +1,33 @@
-import type { EventBridgeEvent, Handler } from "aws-lambda";
 import { Effect, Exit, Config } from "effect";
 import { etCrawlerEffect } from "../../lib/E-T-crawler";
 import { sendMessageToQueue } from "../helpers/helper";
 import {
   buildExtractorAndTransformerConfigLive,
   crawlerLive,
+  mergeETCrawlerConfig,
 } from "../../lib/E-T-crawler/context";
+import { safeParse } from "valibot";
+import { eventSchema } from "@sho/models";
+import { EventSchemaValidationError } from "./error";
+import { issueToLogString } from "../../lib/core/util";
 
-export const handler: Handler<
-  // biome-ignore lint/complexity/noBannedTypes: <explanation>
-  EventBridgeEvent<"Scheduled Event", {}>,
-  unknown // 型つけるのが面倒くさいので
-> = async (_) => {
+export const handler = async (event: unknown) => {
   const program = Effect.gen(function* () {
+    const result = safeParse(eventSchema, event);
+    if (!result.success) {
+      return yield* Effect.fail(new EventSchemaValidationError({ message: `Event schema validation error, detail: ${result.issues.map(issueToLogString).join(", ")}` }));
+    }
+    const extendedConfig = result.output.extendedConfig;
+    const config = yield* mergeETCrawlerConfig(extendedConfig)
+    const configLayer = buildExtractorAndTransformerConfigLive(config)
     const QUEUE_URL = yield* Config.string("QUEUE_URL");
+
     const runnable = etCrawlerEffect
       .pipe(Effect.provide(crawlerLive))
       .pipe(Effect.scoped)
       .pipe(
         Effect.provide(
-          buildExtractorAndTransformerConfigLive({ logDebug: false }),
+          configLayer,
         ),
       );
     const jobs = yield* runnable;

--- a/apps/headless-crawler/lib/core/util.ts
+++ b/apps/headless-crawler/lib/core/util.ts
@@ -18,7 +18,10 @@ export const issueToLogString = (
     | v.UrlIssue<string>
     | v.MinLengthIssue<string, number>
     | v.CheckIssue<{ wageMin: number; wageMax: number }>
-    | v.NumberIssue,
+    | v.NumberIssue
+    | v.BooleanIssue
+    | v.LiteralIssue
+    | v.UnionIssue<v.LiteralIssue>,
 ) => {
   const { received, expected, message } = issue;
   return `received: ${received}\nexpected: ${expected}\nmessage: ${message}`;

--- a/packages/models/src/headless-crawler/jobNumber/event.ts
+++ b/packages/models/src/headless-crawler/jobNumber/event.ts
@@ -1,6 +1,6 @@
 import * as v from "valibot";
-import { extendedConfigSchema } from "./extendedConfig";
+import { etCrawlerConfigWithoutBrowserConfigSchema } from "./config";
 
 export const eventSchema = v.object({
-  extendedConfig: v.optional(extendedConfigSchema),
+  extendedConfig: v.optional(etCrawlerConfigWithoutBrowserConfigSchema),
 });


### PR DESCRIPTION
## 概要
headless-crawlerのJobNumberHandlerで、event経由のconfig注入・バリデーションに対応しました。

## 主な変更点
- eventSchema（valibot）によるeventバリデーションを追加
- event.extendedConfigからconfigを動的にマージし、Lambda実行時の柔軟な設定変更を実現
- context.tsでconfig生成・型定義を整理し、mergeETCrawlerConfig関数を新設
- バリデーションエラー時のエラーハンドリング（EventSchemaValidationError）を追加
- utilのissueToLogStringをvalibotのUnion/Literal/Boolean型に対応

## 目的
Lambdaのeventでconfigを上書きできるようにすることで、デバッグや検証の効率化を図るため。

## 補足
Lambdaのコンソール上からeventのextendedConfigを指定することで、config情報を動的に上書きできるようになりました。これにより、デプロイ不要で設定変更・テストが可能です。

## 確認事項
- eventのextendedConfigでconfigを上書きできること
- バリデーションエラー時に適切なエラーが返ること
- 既存のcrawler挙動に影響がないこと