### PR TITLE
refactor(headless-crawler): Layer構成の統一・依存注入の簡素化

### DIFF
--- a/apps/headless-crawler/functions/ET-JobNumberHandler/handler.ts
+++ b/apps/headless-crawler/functions/ET-JobNumberHandler/handler.ts
@@ -2,9 +2,7 @@ import type { EventBridgeEvent, Handler } from "aws-lambda";
 import { Effect, Exit, Config } from "effect";
 import { etCrawlerEffect } from "../../lib/E-T-crawler";
 import { sendMessageToQueue } from "../helpers/helper";
-import {
-  buildMainLive,
-} from "../../lib/E-T-crawler/context";
+import { buildMainLive } from "../../lib/E-T-crawler/context";
 
 export const handler: Handler<
   // biome-ignore lint/complexity/noBannedTypes: <explanation>
@@ -15,7 +13,7 @@ export const handler: Handler<
     const QUEUE_URL = yield* Config.string("QUEUE_URL");
     const runnable = etCrawlerEffect
       .pipe(Effect.provide(buildMainLive({ logDebug: false })))
-      .pipe(Effect.scoped)
+      .pipe(Effect.scoped);
     const jobs = yield* runnable;
     yield* Effect.forEach(jobs, (job) =>
       sendMessageToQueue({ jobNumber: job.jobNumber }, QUEUE_URL),

--- a/apps/headless-crawler/lib/E-T-crawler/context.ts
+++ b/apps/headless-crawler/lib/E-T-crawler/context.ts
@@ -55,7 +55,7 @@ export class ExtractorAndTransformerConfig extends Context.Tag(
       readonly roughMaxCount: number;
     };
   }
->() { }
+>() {}
 
 const buildExtractorAndTransformerConfigLive = ({
   logDebug,
@@ -82,12 +82,12 @@ const buildExtractorAndTransformerConfigLive = ({
       const args = chromiumOrNull ? chromiumOrNull.args : [];
       const executablePath = chromiumOrNull
         ? yield* Effect.tryPromise({
-          try: () => chromiumOrNull.executablePath(),
-          catch: (error) =>
-            new GetExecutablePathError({
-              message: `Failed to get chromium executable path: ${String(error)}`,
-            }),
-        })
+            try: () => chromiumOrNull.executablePath(),
+            catch: (error) =>
+              new GetExecutablePathError({
+                message: `Failed to get chromium executable path: ${String(error)}`,
+              }),
+          })
         : undefined;
       return {
         getConfig: {
@@ -130,7 +130,7 @@ export class HelloWorkCrawler extends Context.Tag("HelloWorkCrawler")<
       | JobNumberValidationError
     >;
   }
->() { }
+>() {}
 
 export const crawlerLive = Layer.effect(
   HelloWorkCrawler,
@@ -172,11 +172,10 @@ export const crawlerLive = Layer.effect(
   }),
 );
 
-export const buildMainLive = ({
-  logDebug,
-}: {
-  logDebug: boolean;
-}) => crawlerLive.pipe(Layer.provide(buildExtractorAndTransformerConfigLive({ logDebug })));
+export const buildMainLive = ({ logDebug }: { logDebug: boolean }) =>
+  crawlerLive.pipe(
+    Layer.provide(buildExtractorAndTransformerConfigLive({ logDebug })),
+  );
 
 function fetchJobMetaData({
   jobListPage,
@@ -207,11 +206,11 @@ function fetchJobMetaData({
       chunked,
       nextPageEnabled && tmpTotal <= roughMaxCount
         ? Option.some({
-          jobListPage: jobListPage,
-          count: tmpTotal,
-          roughMaxCount,
-          nextPageDelayMs, // 後で構造修正する予定
-        })
+            jobListPage: jobListPage,
+            count: tmpTotal,
+            roughMaxCount,
+            nextPageDelayMs, // 後で構造修正する予定
+          })
         : Option.none(),
     ] as const;
   });

--- a/apps/headless-crawler/lib/E-T-crawler/playground/index.ts
+++ b/apps/headless-crawler/lib/E-T-crawler/playground/index.ts
@@ -1,13 +1,11 @@
 import { Effect } from "effect";
 import { etCrawlerEffect } from "..";
-import {
-  buildMainLive,
-} from "../context";
+import { buildMainLive } from "../context";
 
 async function main() {
   const runnable = etCrawlerEffect
     .pipe(Effect.provide(buildMainLive({ logDebug: true })))
-    .pipe(Effect.scoped)
+    .pipe(Effect.scoped);
   Effect.runPromise(runnable).then((jobNumbers) =>
     console.dir({ jobNumbers }, { depth: null }),
   );


### PR DESCRIPTION
## 概要
Layer構成・依存注入の記述を統一・簡素化しました。

## 主な変更点
- `buildMainLive`関数を新設し、Layer依存注入を一元化
- handler, playgroundでのLayer構成を簡潔に
- context.tsの記述整理

## 目的
- Layer構成の重複・煩雑さを解消し、今後の拡張・保守性を向上させるため

## 補足
jobDetail関連のrunnableの型分離・抽象化は現時点では未対応です。今後のリファクタで対応予定です。

## 確認事項
- 既存の機能・動作に影響がないこと
- Layer依存注入が意図通り一元化されていること