### PR TITLE
feat(headless-crawler): add event schema validation and dynamic debug…

### DIFF
--- a/apps/headless-crawler/functions/ET-JobNumberHandler/error.ts
+++ b/apps/headless-crawler/functions/ET-JobNumberHandler/error.ts
@@ -1,5 +1,7 @@
 import { Data } from "effect";
 
-export class EventSchemaValidationError extends Data.TaggedError("EventSchemaValidationError")<{
-    readonly message: string;
-}> { }
+export class EventSchemaValidationError extends Data.TaggedError(
+  "EventSchemaValidationError",
+)<{
+  readonly message: string;
+}> {}

--- a/apps/headless-crawler/functions/ET-JobNumberHandler/handler.ts
+++ b/apps/headless-crawler/functions/ET-JobNumberHandler/handler.ts
@@ -13,11 +13,20 @@ export const handler = async (event: unknown) => {
     const QUEUE_URL = yield* Config.string("QUEUE_URL");
     const { extendedConfig } = yield* (() => {
       const result = safeParse(eventSchema, event);
-      if (!result.success) return Effect.fail(new EventSchemaValidationError({ message: `detail: ${result.issues.map(issueToLogString).join(", ")}` }));
+      if (!result.success)
+        return Effect.fail(
+          new EventSchemaValidationError({
+            message: `detail: ${result.issues.map(issueToLogString).join(", ")}`,
+          }),
+        );
       return Effect.succeed(result.output);
-    })()
+    })();
     const runnable = etCrawlerEffect
-      .pipe(Effect.provide(buildMainLive({ logDebug: extendedConfig.debugLog || false })))
+      .pipe(
+        Effect.provide(
+          buildMainLive({ logDebug: extendedConfig.debugLog || false }),
+        ),
+      )
       .pipe(Effect.scoped);
     const jobs = yield* runnable;
     yield* Effect.forEach(jobs, (job) =>

--- a/apps/headless-crawler/lib/core/util.ts
+++ b/apps/headless-crawler/lib/core/util.ts
@@ -22,7 +22,6 @@ export const issueToLogString = (
     | v.BooleanIssue
     | v.LiteralIssue
     | v.UnionIssue<v.LiteralIssue>,
-
 ) => {
   const { received, expected, message } = issue;
   return `received: ${received}\nexpected: ${expected}\nmessage: ${message}`;


### PR DESCRIPTION
## 概要

Lambda handler (`ET-JobNumberHandler`) に以下の改善を行いました。

- Lambdaイベントのスキーマバリデーションを追加（valibot利用）
- event経由で `debugLog` 設定を上書き可能に（dynamic config: debugのみ対応）
- schemaバリデーションエラー時の詳細なエラーハンドリングを実装
- valibotのissue型対応を拡張し、バリデーションエラーのログ出力を改善

## 目的

- イベントの型安全性・堅牢性向上
- デバッグや検証時にeventで `debugLog` を柔軟に切り替えられるようにすることで、運用効率を向上

## 補足

- 今回のdynamic configは `debugLog` のみ対応です。今後他の設定もevent経由で上書きできるよう拡張可能です。
- jobDetail関連のrunnable型分離・抽象化は今後対応予定です。