### PR TITLE
feat(job-store-api): クエリパラメータのOpenAPI定義を追加

### DIFF
--- a/apps/job-store-api/src/routes/api/v1/jobs/index.ts
+++ b/apps/job-store-api/src/routes/api/v1/jobs/index.ts
@@ -45,6 +45,65 @@ import { createUnexpectedError } from "./error";
 const INITIAL_JOB_ID = 1; // 初期のcursorとして使用するjobId
 
 const jobListRoute = describeRoute({
+  parameters: [
+    {
+      name: "companyName",
+      in: "query",
+      required: false,
+    },
+    {
+      name: "employeeCountGt",
+      in: "query",
+      required: false,
+    },
+    {
+      name: "employeeCountLt",
+      in: "query",
+      required: false,
+    },
+    {
+      name: "jobDescription",
+      in: "query",
+      required: false,
+    },
+    {
+      name: "jobDescriptionExclude",
+      in: "query",
+      required: false,
+    },
+    {
+      name: "onlyNotExpired",
+      in: "query",
+      required: false,
+    },
+    {
+      name: "orderByReceiveDate",
+      in: "query",
+      required: false,
+      example: "desc"
+    },
+    {
+      name: "addedSince",
+      in: "query",
+      description: "追加された日時（ISO形式）",
+      example: "2025-10-17",
+      required: false
+    },
+    {
+      name: "addedUntil",
+      in: "query",
+      description: "追加された日時（ISO形式）",
+      example: "2025-10-17",
+      required: false
+    },
+    {
+      name: "addedUntil",
+      in: "query",
+      description: "追加された日時（ISO形式）",
+      example: "2025-10-17",
+      required: false
+    }
+  ],
   responses: {
     "200": {
       description: "Successful response",


### PR DESCRIPTION
## 概要

求人情報APIのクエリパラメータについて、OpenAPI仕様に準拠したパラメータ定義（`parameters`）を追加しました。

## 主な変更点

- `jobListRoute`の`parameters`に、会社名・従業員数・求人説明・除外キーワード・有効期限・受信日順・追加日（addedSince/addedUntil）などのクエリパラメータ定義を追加
- 各パラメータに`name`, `in`, `required`, `description`, `example`などの情報を明示

## 背景

API仕様の明示化・自動ドキュメント生成・型安全性向上のため、OpenAPI的なパラメータ定義を整備しました。

## 確認方法

- OpenAPIドキュメントやAPI仕様生成ツールでパラメータ定義が反映されていること
- 既存のAPI挙動に影響がないこと

## 懸念点・今後の方針

現状、OpenAPI的なパラメータ定義（doc記述）と実際の実装コードが分離しており、仕様変更時に両者の乖離が発生しやすい課題があります。

今後、API設計・保守性向上のために以下の選択肢も検討しています。

- REST APIを継続する場合は、OpenAPIスキーマから型やバリデーションを自動生成する仕組み（tRPC, zod, valibot, openapi-typescript等）の導入
- GraphQL等のスキーマ駆動型APIへの移行（型・ドキュメント・実装が一元化できるメリットあり）

API仕様と実装の一貫性・保守性を高めるため、今後の開発方針に応じて検討していきます。