### PR TITLE
chore(job-store-api): ローカルDB永続化ディレクトリをgitignoreに追加・devスクリプト簡素化

### DIFF
--- a/apps/job-store-api/.gitignore
+++ b/apps/job-store-api/.gitignore
@@ -166,3 +166,5 @@ out
 
 .dev.vars
 .wrangler/
+
+d1Local/

--- a/apps/job-store-api/package.json
+++ b/apps/job-store-api/package.json
@@ -6,7 +6,7 @@
 		"deploy": "pnpm build && wrangler deploy",
 		"no-main-deploy": "wrangler versions upload",
 		"build": "tsdown",
-		"dev": "pnpm dump-remote-data && pnpm exec wrangler d1 execute job-store --local --file=./database.sql && wrangler dev;rm -f ./database.sql",
+		"dev": "wrangler dev --persist-to=d1Local",
 		"start": "wrangler dev",
 		"test": "vitest",
 		"cf-typegen": "wrangler types",


### PR DESCRIPTION
## 概要

ローカル開発用のDB永続化ディレクトリ（`d1Local/`）を `.gitignore` に追加し、`dev` スクリプトをシンプル化しました。

## 主な変更点

- `.gitignore` に `d1Local/` を追加し、ローカルDBファイルをgit管理対象外に
- `package.json` の `dev` スクリプトを `wrangler dev --persist-to=d1Local` のみで起動する形に変更

## 背景

Cloudflare D1のローカル永続化機能を使う際、DBファイルがリポジトリに混入しないようにするため。

## 確認方法

- `pnpm dev` で `d1Local/` ディレクトリが生成され、DBが永続化されること
- `d1Local/` がgit管理対象外となっていること
- 既存の開発・デプロイフローに影響がないこと