### PR TITLE
chore(job-store-api): devスクリプトでDB初期化＆database.sql管理に変更

### DIFF
--- a/apps/job-store-api/.gitignore
+++ b/apps/job-store-api/.gitignore
@@ -167,4 +167,4 @@ out
 .dev.vars
 .wrangler/
 
-d1Local/
+database.sql

--- a/apps/job-store-api/package.json
+++ b/apps/job-store-api/package.json
@@ -6,7 +6,7 @@
 		"deploy": "pnpm build && wrangler deploy",
 		"no-main-deploy": "wrangler versions upload",
 		"build": "tsdown",
-		"dev": "wrangler dev --persist-to=d1Local",
+		"dev": "pnpm exec wrangler d1 execute job-store --command=\"DROP TABLE IF EXISTS jobs;DROP TABLE IF EXISTS raw_jobs;\" && pnpm exec wrangler d1 execute job-store --file=database.sql && pnpm exec wrangler dev",
 		"start": "wrangler dev",
 		"test": "vitest",
 		"cf-typegen": "wrangler types",


### PR DESCRIPTION
## 概要

- 開発用DBの初期化手順を `dev` スクリプトに統合
- `.gitignore` の `d1Local/` 除外を削除し、`database.sql` を除外対象に追加

## 変更内容

- `package.json` の `dev` スクリプトを、DB初期化＋`wrangler dev`起動に変更
- `.gitignore` の管理対象を見直し

## 背景・目的

- ローカルDBの初期化・管理を簡素化し、開発環境の再現性を向上
- 不要なファイルの除外ルールを整理

## 補足

- 以前は `wrangler dev --persist-to=d1Local` オプションを利用していましたが、ローカルでデータが保存されない問題がありました。
- Cloudflare公式の [persist-to オプションのベストプラクティス](https://developers.cloudflare.com/d1/best-practices/local-development/#persist-data) を参考にしましたが、期待通り動作しなかったため、DB初期化＋`database.sql`管理方式に変更しました。