### PR TITLE
feat(headless-crawler): LambdaのタイムアウトとmaxCountを増加

### DIFF
--- a/apps/headless-crawler/infra/constructs/E-T-JobNumber.ts
+++ b/apps/headless-crawler/infra/constructs/E-T-JobNumber.ts
@@ -23,7 +23,7 @@ export class JobNumberExtractAndTransformConstruct extends Construct {
       entry: "functions/ET-JobNumberHandler/handler.ts",
       handler: "handler",
       memorySize: 1024,
-      timeout: Duration.seconds(240),
+      timeout: Duration.seconds(480),
       environment: {
         QUEUE_URL: process.env.QUEUE_URL || "",
       },

--- a/apps/headless-crawler/lib/E-T-crawler/context.ts
+++ b/apps/headless-crawler/lib/E-T-crawler/context.ts
@@ -90,7 +90,7 @@ const extractorAndTransfomerConfigLive = Layer.effect(
           employmentType: "RegularEmployee",
           searchPeriod: "today",
         },
-        roughMaxCount: 800,
+        roughMaxCount: 1600,
       },
     } as const;
   }),


### PR DESCRIPTION
### 背景
従来の最大件数では取得できないジョブが発生していたため、より多くの件数に対応できるようにする必要がありました。

### PRで解決すること
- Lambda関数のタイムアウト値を240秒から480秒へ延長
- 対応可能な最大件数（roughMaxCount）を800から1600へ増加

### 影響範囲
- headless-crawler関連のLambda処理
- ジョブ詳細取得の件数上限

### テスト
- 静的テストのみ実施。型エラーや構文エラーはありませんでした。
- 実際の動作確認・結合テストは未実施です。

### 備考
- パフォーマンスやコストへの影響は今後の運用状況を見て調整予定です。