### PR TITLE
feat(headless-crawler): Lambda失敗時にresult.causeを再スローしてエラーを伝搬

### DIFF
--- a/apps/headless-crawler/functions/E-T-L-JobDetailHandler/handler.ts
+++ b/apps/headless-crawler/functions/E-T-L-JobDetailHandler/handler.ts
@@ -39,5 +39,6 @@ export const handler: SQSHandler = async (event: SQSEvent) => {
     console.log("Lambda job succeeded:", result.value);
   } else {
     console.error("Lambda job failed", result.cause);
+    throw new Error(JSON.stringify(result.cause, null, 2));
   }
 };


### PR DESCRIPTION
# feat(headless-crawler): Lambda失敗時にresult.causeを再スローしてエラーを伝搬

## 概要（TL;DR）
Lambda の ETL ジョブ処理で、ジョブが失敗しているのにローカル/デバッグ時に success と表示され分かりにくかった問題を解消します。`result.cause` を JSON 化して `Error` として再スローすることで、Lambda 実行が失敗として扱われるように変更しました。これにより SQS のリトライや DLQ の挙動が期待通りになります。

## 変更内容
- 変更ファイル:
  - `apps/headless-crawler/functions/E-T-L-JobDetailHandler/handler.ts`
- 変更点（要約）:
  - ジョブ失敗時に `console.error` を出力した後、`throw new Error(JSON.stringify(result.cause, null, 2));` を追加してエラーを再スローするように変更。

## 背景（重要）
ローカルで Lambda のテスト／デバッグをしていると、ジョブ処理が内部的に失敗しているにもかかわらずハンドラが成功扱い（success）になってしまい、原因特定が非常に分かりにくい状況がありました。  
この変更は主に個人的なデバッグ効率向上と運用上の検知性改善を目的とした設計・運用改善です。

## 目的
- ローカル/ステージングでのデバッグ時に「失敗なのに success と出る」混乱を防ぐ
- SQS の再試行や DLQ など既存の障害回復機構が正しく動作するようにする

## 期待される効果
- ジョブ失敗時に Lambda が失敗として扱われ、SQS の retry / DLQ の動作がトリガーされる
- デバッグ時に失敗箇所が明示化されるため原因追跡が容易になる

## 備考（レビュワー）
- これは個人的なデザイン／運用改善の変更で、現時点では正式なレビュワーは不要です。必要なら後からチームに共有します。
