### PR TITLE
fix(api): セキュリティ強化（レート制限・LIKE エスケープ・ヘッダー・バリデーション）

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -122,6 +122,7 @@ Cloudflare Workers + Hono。
 - **インフラ層**: `src/infra/db.ts` に `JobStoreDB`（Effect Context.Tag）と `createD1DB`（D1Dialect 組み立て）を集約。`JobStoreDB.main(binding)` で DB クライアントを生成。
 - **エラー**: `Data.TaggedError` で型安全なエラーハンドリング。コントローラーで `Effect.match` により分岐。
 - **ページネーション**: ページ番号方式。
+- **ミドルウェア**: `src/middleware/` に共通ミドルウェアを集約。API キー検証（`api-key.ts`）、D1 Token Bucket レート制限（`rate-limit.ts`）、セキュリティヘッダー（`security-headers.ts`）。
 
 ---
 

--- a/apps/backend/api/src/app/companies.ts
+++ b/apps/backend/api/src/app/companies.ts
@@ -1,9 +1,14 @@
 import { Company } from "@sho/models";
-import { Effect, Schema } from "effect";
+import { Data, Effect, Schema } from "effect";
 import { Hono } from "hono";
 import { UpsertCompanyCommand } from "../cqrs/commands";
 import { FetchJobError, FindCompanyQuery } from "../cqrs/queries";
 import { JobStoreDB } from "../infra/db";
+import { verifyApiKey } from "../middleware/api-key";
+
+class InvalidJsonError extends Data.TaggedError("InvalidJsonError")<{
+  readonly message: string;
+}> {}
 
 const app = new Hono<{ Bindings: Env }>()
   .get("/:establishmentNumber", (c) => {
@@ -39,20 +44,16 @@ const app = new Hono<{ Bindings: Env }>()
       ),
     );
   })
-  .post("/", (c, next) => {
-    const apiKey = c.req.header("x-api-key");
-    const validApiKey = c.env.API_KEY;
-    if (!apiKey || apiKey !== validApiKey) {
-      return c.json({ message: "Invalid API key" }, 401);
-    }
-    return next();
-  })
-  .post("/", async (c) => {
-    const body = await c.req.json();
+  .post("/", verifyApiKey)
+  .post("/", (c) => {
     const db = JobStoreDB.main(c.env.DB);
 
     return Effect.runPromise(
       Effect.gen(function* () {
+        const body = yield* Effect.tryPromise({
+          try: () => c.req.json(),
+          catch: () => new InvalidJsonError({ message: "Invalid JSON body" }),
+        });
         const company = yield* Schema.decodeUnknown(Company)(body);
         const cmd = yield* UpsertCompanyCommand;
         return yield* cmd.run(company);
@@ -62,8 +63,14 @@ const app = new Hono<{ Bindings: Env }>()
         Effect.match({
           onSuccess: (result) => c.json(result),
           onFailure: (error) => {
-            console.error(error);
-            return c.json({ message: "internal server error" }, 500);
+            switch (error._tag) {
+              case "ParseError":
+              case "InvalidJsonError":
+                return c.json({ message: error.message }, 400);
+              default:
+                console.error(error);
+                return c.json({ message: "internal server error" }, 500);
+            }
           },
         }),
       ),

--- a/apps/backend/api/src/app/jobs.ts
+++ b/apps/backend/api/src/app/jobs.ts
@@ -16,6 +16,7 @@ import {
 } from "../cqrs/queries";
 import { SearchFilterSchema } from "../cqrs/schema";
 import { JobStoreDB } from "../infra/db";
+import { verifyApiKey } from "../middleware/api-key";
 
 // --- スキーマ ---
 
@@ -361,14 +362,7 @@ const app = new Hono<{ Bindings: Env }>()
   .post(
     "/",
     jobInsertRoute,
-    (c, next) => {
-      const apiKey = c.req.header("x-api-key");
-      const validApiKey = c.env.API_KEY;
-      if (!apiKey || apiKey !== validApiKey) {
-        return c.json({ message: "Invalid API key" }, 401);
-      }
-      return next();
-    },
+    verifyApiKey,
     effectValidator(
       "json",
       Schema.standardSchemaV1(insertJobRequestBodySchema),

--- a/apps/backend/api/src/cqrs/queries.ts
+++ b/apps/backend/api/src/cqrs/queries.ts
@@ -10,6 +10,11 @@ import {
 } from "../infra/db";
 import type { SearchFilter } from "./schema";
 
+/** LIKE クエリ用: % と _ をエスケープしてワイルドカードインジェクションを防止 */
+function escapeLike(value: string): string {
+  return value.replace(/%/g, "\\%").replace(/_/g, "\\_");
+}
+
 // --- エラー ---
 
 export class FetchJobError extends Data.TaggedError("FetchJobError")<{
@@ -85,7 +90,7 @@ export class FetchJobsPageQuery extends Effect.Service<FetchJobsPageQuery>()(
                 query = query.where(
                   "companyName",
                   "like",
-                  `%${filter.companyName}%`,
+                  `%${escapeLike(filter.companyName)}%`,
                 );
               }
               if (filter.employeeCountGt !== undefined) {
@@ -106,14 +111,14 @@ export class FetchJobsPageQuery extends Effect.Service<FetchJobsPageQuery>()(
                 query = query.where(
                   "jobDescription",
                   "like",
-                  `%${filter.jobDescription}%`,
+                  `%${escapeLike(filter.jobDescription)}%`,
                 );
               }
               if (filter.jobDescriptionExclude) {
                 query = query.where(
                   "jobDescription",
                   "not like",
-                  `%${filter.jobDescriptionExclude}%`,
+                  `%${escapeLike(filter.jobDescriptionExclude)}%`,
                 );
               }
               if (filter.onlyNotExpired) {
@@ -139,7 +144,7 @@ export class FetchJobsPageQuery extends Effect.Service<FetchJobsPageQuery>()(
                 query = query.where(
                   "occupation",
                   "like",
-                  `%${filter.occupation}%`,
+                  `%${escapeLike(filter.occupation)}%`,
                 );
               }
               if (filter.employmentType) {
@@ -159,14 +164,14 @@ export class FetchJobsPageQuery extends Effect.Service<FetchJobsPageQuery>()(
                 query = query.where(
                   "workPlace",
                   "like",
-                  `%${filter.workPlace}%`,
+                  `%${escapeLike(filter.workPlace)}%`,
                 );
               }
               if (filter.qualifications) {
                 query = query.where(
                   "qualifications",
                   "like",
-                  `%${filter.qualifications}%`,
+                  `%${escapeLike(filter.qualifications)}%`,
                 );
               }
               if (filter.jobCategory) {
@@ -179,14 +184,14 @@ export class FetchJobsPageQuery extends Effect.Service<FetchJobsPageQuery>()(
                 query = query.where(
                   "education",
                   "like",
-                  `%${filter.education}%`,
+                  `%${escapeLike(filter.education)}%`,
                 );
               }
               if (filter.industryClassification) {
                 query = query.where(
                   "industryClassification",
                   "like",
-                  `%${filter.industryClassification}%`,
+                  `%${escapeLike(filter.industryClassification)}%`,
                 );
               }
 

--- a/apps/backend/api/src/index.ts
+++ b/apps/backend/api/src/index.ts
@@ -4,8 +4,12 @@ import { openAPIRouteHandler } from "hono-openapi";
 import companies from "./app/companies";
 import jobs from "./app/jobs";
 import stats from "./app/stats";
+import { rateLimit } from "./middleware/rate-limit";
+import { securityHeaders } from "./middleware/security-headers";
 
 const app = new Hono()
+  .use("*", rateLimit)
+  .use("*", securityHeaders)
   .use("*", async (c, next) => {
     const start = Date.now();
 

--- a/apps/backend/api/src/middleware/api-key.ts
+++ b/apps/backend/api/src/middleware/api-key.ts
@@ -1,0 +1,11 @@
+import type { Context, Next } from "hono";
+
+/** x-api-key ヘッダーを検証するミドルウェア */
+export function verifyApiKey(c: Context<{ Bindings: Env }>, next: Next) {
+  const apiKey = c.req.header("x-api-key");
+  const validApiKey = c.env.API_KEY;
+  if (!apiKey || apiKey !== validApiKey) {
+    return c.json({ message: "Invalid API key" }, 401);
+  }
+  return next();
+}

--- a/apps/backend/api/src/middleware/rate-limit.ts
+++ b/apps/backend/api/src/middleware/rate-limit.ts
@@ -1,0 +1,49 @@
+import type { Context, Next } from "hono";
+
+const MAX_TOKENS = 100;
+const REFILL_RATE = 10; // tokens per second
+
+/**
+ * D1 Token Bucket によるグローバルレート制限。
+ * `_rate_limit` テーブルに1行だけ持ち、トークンを管理する。
+ */
+export async function rateLimit(c: Context<{ Bindings: Env }>, next: Next) {
+  const db = c.env.DB;
+
+  try {
+    await db.batch([
+      db.prepare(
+        `CREATE TABLE IF NOT EXISTS _rate_limit (
+          id TEXT PRIMARY KEY,
+          tokens REAL NOT NULL,
+          last_refill TEXT NOT NULL
+        )`,
+      ),
+      db
+        .prepare(
+          `INSERT OR IGNORE INTO _rate_limit (id, tokens, last_refill)
+         VALUES ('global', ?, datetime('now'))`,
+        )
+        .bind(MAX_TOKENS),
+    ]);
+
+    const result = await db
+      .prepare(
+        `UPDATE _rate_limit
+         SET tokens = MIN(?, tokens + (julianday('now') - julianday(last_refill)) * 86400 * ?) - 1,
+             last_refill = datetime('now')
+         WHERE id = 'global'
+         RETURNING tokens`,
+      )
+      .bind(MAX_TOKENS, REFILL_RATE)
+      .first<{ tokens: number }>();
+
+    if (result && result.tokens < 0) {
+      return c.json({ message: "Too many requests" }, 429);
+    }
+  } catch (e) {
+    console.error("[rateLimit] error:", e);
+  }
+
+  return next();
+}

--- a/apps/backend/api/src/middleware/security-headers.ts
+++ b/apps/backend/api/src/middleware/security-headers.ts
@@ -1,0 +1,10 @@
+import type { Context, Next } from "hono";
+
+/** セキュリティヘッダーを付与するミドルウェア */
+export async function securityHeaders(c: Context, next: Next) {
+  await next();
+  c.header("X-Content-Type-Options", "nosniff");
+  c.header("X-Frame-Options", "DENY");
+  c.header("Referrer-Policy", "strict-origin-when-cross-origin");
+  c.header("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
+}

--- a/apps/backend/api/test/unit.spec.ts
+++ b/apps/backend/api/test/unit.spec.ts
@@ -170,3 +170,50 @@ describe("求人詳細", () => {
     expect(response.status).toBe(200);
   });
 });
+
+// --- セキュリティ ---
+
+describe("セキュリティ", () => {
+  it("レスポンスにセキュリティヘッダーが含まれる", async () => {
+    const response = await workerFetch("/jobs");
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(response.headers.get("x-frame-options")).toBe("DENY");
+    expect(response.headers.get("referrer-policy")).toBe(
+      "strict-origin-when-cross-origin",
+    );
+  });
+
+  it("レート制限を超えると 429 を返す", async () => {
+    // まず1回リクエストしてテーブルを確実に作成
+    await workerFetch("/jobs");
+    // トークンを枯渇させて refill されないよう last_refill を現在時刻に
+    const db = MOCK_ENV.DB;
+    await db
+      .prepare(
+        "UPDATE _rate_limit SET tokens = -100, last_refill = datetime('now') WHERE id = 'global'",
+      )
+      .run();
+    const response = await workerFetch("/jobs");
+    expect(response.status).toBe(429);
+  });
+
+  it("LIKE ワイルドカードがエスケープされる", async () => {
+    const response = await workerFetch("/jobs?companyName=%25%25%25");
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    // %%% はリテラル文字として扱われるため結果は 0 件
+    expect(data.meta.totalCount).toBe(0);
+  });
+
+  it("Companies POST に不正な JSON を送ると 400 を返す", async () => {
+    const response = await workerFetch("/companies", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": "test-api-key",
+      },
+      body: "{broken",
+    });
+    expect(response.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- ペネトレーションテストで発見した脆弱性を修正
- D1 Token Bucket レート制限、LIKE エスケープ、セキュリティヘッダー、バリデーション強化

## Background & Motivation
- 攻撃者目線のセキュリティレビューで以下を確認:
  - LIKE ワイルドカードインジェクション（`?companyName=%%%` で全件取得可能）
  - レート制限なし（ブルートフォース可能）
  - セキュリティヘッダー未設定
  - Companies POST の JSON パースエラー未ハンドリング
  - API キー検証がインラインで重複

## Design Decisions
- **D1 Token Bucket レート制限**
  - インメモリではなく D1 に保存（Workers はメモリ保持の保証なし）
  - `_rate_limit` テーブルは `CREATE TABLE IF NOT EXISTS` で自動作成（マイグレーション管理外）
  - `db.batch()` で CREATE + INSERT を1回の通信で実行
  - 100 tokens / 10 tokens per second のリフィルレート
- **タイミングセーフ比較は不採用**
  - レート制限があればタイミング攻撃は実質不可能
  - Cloudflare Workers のネットワークジッタでも困難
- **LIKE エスケープ**
  - `escapeLike()` で `%` と `_` をバックスラッシュエスケープ
  - Kysely のパラメータバインディングでは防げない（SQL 仕様）
- **InvalidJsonError の導入**
  - `FetchJobError` の流用をやめ、専用の TaggedError を定義

## Changes

### apps/backend/api
- **新規: `src/middleware/api-key.ts`** — API キー検証ミドルウェア
- **新規: `src/middleware/rate-limit.ts`** — D1 Token Bucket レート制限
- **新規: `src/middleware/security-headers.ts`** — セキュリティヘッダー付与
- **変更: `src/index.ts`** — rateLimit + securityHeaders ミドルウェアを追加
- **変更: `src/app/jobs.ts`** — インライン API キー検証を verifyApiKey に置換
- **変更: `src/app/companies.ts`** — verifyApiKey 導入、InvalidJsonError 追加、Effect.tryPromise で JSON パースエラーをハンドリング
- **変更: `src/cqrs/queries.ts`** — escapeLike() を追加し全 LIKE クエリに適用
- **変更: `test/unit.spec.ts`** — セキュリティテスト 4 件追加

## Test Plan
- `pnpm test` で全14テストパス
- セキュリティヘッダーの存在確認テスト
- レート制限（トークン枯渇時に 429 返却）テスト
- LIKE ワイルドカードエスケープテスト（`%%%` で 0 件）
- Companies POST 不正 JSON テスト（400 返却）
