### PR TITLE
feat(frontend): 求人詳細ページに同じ企業の他の求人一覧を追加

### DIFF
--- a/apps/frontend/hello-work-job-searcher/src/app/jobs/[jobNumber]/JobDetailPage.stories.tsx
+++ b/apps/frontend/hello-work-job-searcher/src/app/jobs/[jobNumber]/JobDetailPage.stories.tsx
@@ -14,6 +14,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     job: mockJobs[0],
+    relatedJobs: [],
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -28,6 +29,7 @@ export const Default: Story = {
 export const AnotherJob: Story = {
   args: {
     job: mockJobs[4],
+    relatedJobs: [],
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/apps/frontend/hello-work-job-searcher/src/app/jobs/[jobNumber]/JobDetailPage_client.tsx
+++ b/apps/frontend/hello-work-job-searcher/src/app/jobs/[jobNumber]/JobDetailPage_client.tsx
@@ -5,7 +5,13 @@ import { JobDetailCard } from "@/components/features/detail/JobDetail";
 import type { JobDetail } from "@/dto";
 import styles from "./JobDetailPage.module.css";
 
-export function JobDetailPage({ job }: { job: JobDetail }) {
+export function JobDetailPage({
+  job,
+  relatedJobs,
+}: {
+  job: JobDetail;
+  relatedJobs: JobDetail[];
+}) {
   return (
     <div className={styles.container}>
       <div className={styles.header}>
@@ -13,7 +19,7 @@ export function JobDetailPage({ job }: { job: JobDetail }) {
           &larr; 求人一覧に戻る
         </Link>
       </div>
-      <JobDetailCard jobDetail={job} />
+      <JobDetailCard jobDetail={job} relatedJobs={relatedJobs} />
     </div>
   );
 }

--- a/apps/frontend/hello-work-job-searcher/src/app/jobs/[jobNumber]/page.tsx
+++ b/apps/frontend/hello-work-job-searcher/src/app/jobs/[jobNumber]/page.tsx
@@ -20,5 +20,16 @@ export default async function Page({
   if (!job) {
     return <div>求人が見つかりませんでした。</div>;
   }
-  return <JobDetailPage job={job} />;
+
+  const relatedJobs = job.companyName
+    ? await jobStoreClient.jobs
+        .$get({ query: { companyName: job.companyName } })
+        .then((r) => (r.ok ? r.json() : null))
+        .then((data) =>
+          data ? data.jobs.filter((j) => j.jobNumber !== job.jobNumber) : [],
+        )
+        .catch(() => [])
+    : [];
+
+  return <JobDetailPage job={job} relatedJobs={relatedJobs} />;
 }

--- a/apps/frontend/hello-work-job-searcher/src/components/features/detail/JobDetail.module.css
+++ b/apps/frontend/hello-work-job-searcher/src/components/features/detail/JobDetail.module.css
@@ -36,6 +36,41 @@
   font-size: 0.9375rem;
 }
 
+.related-jobs {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.related-jobs li a {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--border, gainsboro);
+  border-radius: 0.375rem;
+  background: var(--background, #fff);
+  text-decoration: none;
+  color: inherit;
+  transition: background 0.15s;
+}
+
+.related-jobs li a:hover {
+  background: var(--hover-bg, #f5f5f5);
+}
+
+.related-occupation {
+  font-weight: 600;
+}
+
+.related-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
 @media (max-width: 768px) {
   .layout-job-detail {
     padding: 1rem;

--- a/apps/frontend/hello-work-job-searcher/src/components/features/detail/JobDetail.stories.tsx
+++ b/apps/frontend/hello-work-job-searcher/src/components/features/detail/JobDetail.stories.tsx
@@ -11,6 +11,7 @@ type Story = StoryObj<typeof meta>;
 
 export const FullData: Story = {
   args: {
+    relatedJobs: [],
     jobDetail: {
       jobNumber: "13080-12345678",
       companyName: "株式会社サンプル",
@@ -50,6 +51,7 @@ export const FullData: Story = {
 
 export const LongDescription: Story = {
   args: {
+    relatedJobs: [],
     jobDetail: {
       jobNumber: "13080-11111111",
       companyName: "株式会社ロングテキスト",
@@ -90,6 +92,7 @@ export const LongDescription: Story = {
 
 export const MinimalData: Story = {
   args: {
+    relatedJobs: [],
     jobDetail: {
       jobNumber: "27010-87654321",
       companyName: null,

--- a/apps/frontend/hello-work-job-searcher/src/components/features/detail/JobDetail.tsx
+++ b/apps/frontend/hello-work-job-searcher/src/components/features/detail/JobDetail.tsx
@@ -1,10 +1,15 @@
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
 import { Label } from "@/components/ui/Label";
 import type { JobDetail } from "@/dto";
 import { formatDate } from "@/util";
 import styles from "./JobDetail.module.css";
 import { WorkPlaceMap } from "./WorkPlaceMap";
 
-export function JobDetailCard(props: { jobDetail: JobDetail }) {
+export function JobDetailCard(props: {
+  jobDetail: JobDetail;
+  relatedJobs: JobDetail[];
+}) {
   const {
     jobNumber,
     companyName,
@@ -17,6 +22,7 @@ export function JobDetailCard(props: { jobDetail: JobDetail }) {
     workingHours,
     qualifications,
   } = props.jobDetail;
+  const { relatedJobs } = props;
   return (
     <article className={styles["layout-job-detail"]}>
       <h2>求人番号: {jobNumber}</h2>
@@ -38,6 +44,41 @@ export function JobDetailCard(props: { jobDetail: JobDetail }) {
         </Label>
         <Label term="必須資格">{qualifications ?? "未記載"}</Label>
       </div>
+
+      {relatedJobs.length > 0 && (
+        <>
+          <h2>この企業の他の求人</h2>
+          <ul className={styles["related-jobs"]}>
+            {relatedJobs.map((j) => (
+              <li key={j.jobNumber}>
+                <Link href={`/jobs/${j.jobNumber}`}>
+                  <span className={styles["related-occupation"]}>
+                    {j.occupation}
+                  </span>
+                  <span className={styles["related-tags"]}>
+                    <Badge variant="secondary">{j.employmentType}</Badge>
+                    {j.wage && (
+                      <Badge variant="outline">
+                        {j.wage.min.toLocaleString()}円〜
+                        {j.wage.max.toLocaleString()}円
+                      </Badge>
+                    )}
+                    {j.workingHours && (
+                      <Badge variant="outline">
+                        {j.workingHours.start ?? "?"}〜
+                        {j.workingHours.end ?? "?"}
+                      </Badge>
+                    )}
+                    {j.workPlace && (
+                      <Badge variant="outline">{j.workPlace}</Badge>
+                    )}
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
     </article>
   );
 }

--- a/apps/frontend/hello-work-job-searcher/src/lib/backend-client.mock.ts
+++ b/apps/frontend/hello-work-job-searcher/src/lib/backend-client.mock.ts
@@ -7,7 +7,6 @@ export type JobDetailResponse = InferResponseType<
   Client["jobs"][":jobNumber"]["$get"],
   200
 >;
-
 // --- モックデータ ---
 
 const baseJob: JobDetailResponse = {
@@ -118,8 +117,20 @@ function makeResponse<T>(data: T, status = 200) {
 
 export const jobStoreClient = {
   jobs: {
-    $get: async () => makeResponse(_jobList),
-    [":jobNumber"]: {
+    $get: async (opts?: { query?: { companyName?: string } }) => {
+      const companyName = opts?.query?.companyName;
+      if (companyName) {
+        const filtered = _jobList.jobs.filter(
+          (j) => j.companyName === companyName,
+        );
+        return makeResponse({
+          jobs: filtered,
+          meta: { totalCount: filtered.length, page: 1, totalPages: 1 },
+        });
+      }
+      return makeResponse(_jobList);
+    },
+    ":jobNumber": {
       $get: async ({ param }: { param: { jobNumber: string } }) => {
         const job = _jobMap.get(param.jobNumber);
         return makeResponse(job ?? null);


### PR DESCRIPTION
## Summary
求人詳細ページの下部に、同じ企業（companyName）が出している他の求人を一覧表示する機能を追加。

## Background & Motivation
- 求人詳細ページを見ているユーザーが、同じ企業の別ポジションにも興味を持つケースは多い
- 現状では一覧ページに戻って企業名で検索し直す必要があり、導線が悪い
- 詳細ページから直接関連求人に遷移できるようにすることで、ユーザーの回遊性を向上させる

## Design Decisions
- **companyName で検索**: `establishmentNumber` での紐付けも検討したが、jobs テーブルでは nullable であり、既存の `/jobs` API に `companyName` フィルターが既にあるためそちらを活用。FK 制約もないため、companyName ベースの方が実用的
- **Badge タグでメタ情報表示**: 雇用形態（secondary バッジ）、賃金・勤務時間・勤務地（outline バッジ）をタグで表示。一覧性を保ちつつ情報密度を確保
- **賃金カンマ区切り**: `toLocaleString()` で読みやすく整形
- **エラー時はフォールバック**: 会社名が null の場合や API エラー時は空配列を返し、関連求人セクションを非表示にする（ページ全体のレンダリングをブロックしない）

## Changes

### `apps/frontend/hello-work-job-searcher/`

- **`src/app/jobs/[jobNumber]/page.tsx`**: job 取得後に `companyName` で `/jobs` API を叩き、自身を除外した関連求人を取得
- **`src/app/jobs/[jobNumber]/JobDetailPage_client.tsx`**: `relatedJobs: JobDetail[]` props を追加し `JobDetailCard` に伝搬
- **`src/components/features/detail/JobDetail.tsx`**: 関連求人がある場合に「この企業の他の求人」セクションを表示。Badge コンポーネントで雇用形態・賃金・勤務時間・勤務地をタグ表示
- **`src/components/features/detail/JobDetail.module.css`**: 関連求人リスト（`.related-jobs`, `.related-occupation`, `.related-tags`）のスタイル追加
- **`src/lib/backend-client.mock.ts`**: モッククライアントの `$get` に `companyName` フィルタリング対応を追加。不要な会社モックを削除
- **`src/app/jobs/[jobNumber]/JobDetailPage.stories.tsx`**: `relatedJobs: []` を追加
- **`src/components/features/detail/JobDetail.stories.tsx`**: `relatedJobs: []` を追加

## Test Plan
- [x] `pnpm type-check` 全パッケージ通過
- [x] `pnpm exec biome check` 通過
- [x] Storybook で JobDetailRSCPage / Default ストーリーにて関連求人表示を目視確認
- [ ] CI（pr-checks.yml）で build / type-check / test / lint 通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
