### PR TITLE
feat(collector): Lambda の /tmp 使用量ロギングを追加

### DIFF
--- a/apps/backend/collector/infra/functions/job-detail-handler/handler.ts
+++ b/apps/backend/collector/infra/functions/job-detail-handler/handler.ts
@@ -9,6 +9,7 @@ import {
   JobDetailTransformer,
   processJob,
 } from "../../../lib/job-detail-crawler";
+import { logTmpUsage } from "../tmp-usage";
 
 // ── SQS メッセージスキーマ ──
 
@@ -69,6 +70,8 @@ export const handler = async (event: SQSEvent): Promise<void> => {
     console.error("No records in SQS event");
     return;
   }
+
+  await logTmpUsage("job-detail-etl:start");
 
   const parsed = Schema.decodeUnknownSync(SqsJobMessage)(
     JSON.parse(record.body),

--- a/apps/backend/collector/infra/functions/job-number-handler/handler.ts
+++ b/apps/backend/collector/infra/functions/job-number-handler/handler.ts
@@ -5,8 +5,8 @@ import {
   crawlJobLinks,
   JobNumberCrawlerConfig,
 } from "../../../lib/job-number-crawler/crawl";
-import { logTmpUsage } from "../tmp-usage";
 import { JobDetailQueue } from "../../sqs";
+import { logTmpUsage } from "../tmp-usage";
 
 export const handler = async () => {
   await logTmpUsage("job-number-crawler:start");

--- a/apps/backend/collector/infra/functions/job-number-handler/handler.ts
+++ b/apps/backend/collector/infra/functions/job-number-handler/handler.ts
@@ -5,9 +5,12 @@ import {
   crawlJobLinks,
   JobNumberCrawlerConfig,
 } from "../../../lib/job-number-crawler/crawl";
+import { logTmpUsage } from "../tmp-usage";
 import { JobDetailQueue } from "../../sqs";
 
 export const handler = async () => {
+  await logTmpUsage("job-number-crawler:start");
+
   const jobs = await Effect.scoped(
     Effect.gen(function* () {
       const queue = yield* JobDetailQueue;

--- a/apps/backend/collector/infra/functions/tmp-usage.ts
+++ b/apps/backend/collector/infra/functions/tmp-usage.ts
@@ -1,0 +1,41 @@
+import { readdir, stat, statfs } from "node:fs/promises";
+import { join } from "node:path";
+
+const TMP_DIR = "/tmp";
+
+const toMB = (bytes: number) => Math.round((bytes / 1024 / 1024) * 10) / 10;
+
+export async function logTmpUsage(label: string): Promise<void> {
+  try {
+    const [fs, entries] = await Promise.all([
+      statfs(TMP_DIR),
+      readdir(TMP_DIR, { withFileTypes: true }),
+    ]);
+
+    const totalMB = toMB(fs.blocks * fs.bsize);
+    const availableMB = toMB(fs.bavail * fs.bsize);
+
+    // /tmp 直下のエントリだけサイズ取得（再帰しない）
+    const topLevel = await Promise.all(
+      entries.map(async (entry) => {
+        try {
+          const s = await stat(join(TMP_DIR, entry.name));
+          return { path: entry.name, sizeMB: toMB(s.size) };
+        } catch {
+          return { path: entry.name, sizeMB: 0 };
+        }
+      }),
+    );
+
+    const sorted = topLevel.sort((a, b) => b.sizeMB - a.sizeMB).slice(0, 5);
+
+    console.log(
+      JSON.stringify({
+        label,
+        tmpUsage: { totalMB, availableMB, entries: sorted },
+      }),
+    );
+  } catch (e) {
+    console.log(JSON.stringify({ label, tmpUsageError: String(e) }));
+  }
+}


### PR DESCRIPTION
## Summary\n- statfs + readdir で /tmp の空き容量と直下エントリのサイズをハンドラー開始時にログ出力\n- シェル実行なし、Node.js 標準 API のみ使用\n- Warm Start 時の /tmp 枯渇原因の特定を容易にする\n\n## Test plan\n- [x] pnpm type-check パス\n- [x] pnpm test 全テストパス\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)