### PR TITLE
feat(logger): @sho/logger パッケージと /debug skill を追加

### DIFF
--- a/.claude/rules/general.md
+++ b/.claude/rules/general.md
@@ -4,6 +4,24 @@
 
 ## devbox
 
-- CLI ツール（`gh`, `awscli` 等）は devbox で管理されている
+- CLI ツール（`gh`, `awscli`, `vercel`, `wrangler` 等）は devbox で管理されている
 - コマンドが見つからない場合は `devbox run <command>` で実行する
 - インストール済みツールは `devbox.json` を参照
+
+## ロギング
+
+- 構造化ログのキー名規約は [docs/LOGGING.md](../../docs/LOGGING.md) を参照
+- 失敗ログには **必ず** `service` / `_tag` / `jobNumber`（該当時）を含める
+- 横断デバッグは `/debug` skill を使う
+
+## ログ取得 CLI 認証
+
+3 基盤のログを CLI から取得するための認証前提:
+
+| 基盤 | CLI | 認証 |
+|------|-----|------|
+| Collector | `aws logs` | `AWS_PROFILE=crawler-debug` |
+| API (Workers) | `wrangler tail job-store` | `wrangler login` |
+| Frontend (Vercel) | `vercel logs` | `vercel login` + `vercel link` (apps/frontend/hello-work-job-searcher で実行) |
+
+認証が切れている場合は `/debug` skill が検知して再ログインを促す。

--- a/.claude/rules/logger.md
+++ b/.claude/rules/logger.md
@@ -1,0 +1,39 @@
+# Logger (packages/logger)
+
+3 サービス横断の構造化ログライブラリ。[docs/LOGGING.md](../../docs/LOGGING.md) のキー名規約を実装する。
+
+## API
+
+- `makeLogger(service)` → `{ LoggerLayer, runLog }` を返す
+- `logErrorCause(msg, cause)` → Cause から `_tag` / `error.message` を抽出してエラーログを出す
+
+## 設計
+
+- Effect の `Logger.make` + `Logger.replace` で差し替え
+- `service` はファクトリ引数で束縛
+- `Schema.Struct({ _tag, message })` で `Data.TaggedError` を型安全に抽出
+- Workers / Node / Edge すべてで動作（`console.*` と `Date` と `JSON` のみ使用）
+
+## 利用側
+
+各サービスで薄いラッパを用意する:
+
+```ts
+// apps/backend/api/src/log.ts
+import { logErrorCause, makeLogger } from "@sho/logger";
+export const { LoggerLayer, runLog } = makeLogger("api");
+export { logErrorCause };
+```
+
+service ごとに個別の LoggerLayer を持つため、サービス名はラッパでのみ決定される。
+
+## コマンド
+
+```bash
+pnpm --filter @sho/logger build       # tsdown ビルド
+pnpm --filter @sho/logger type-check  # 型チェック
+```
+
+## 依存
+
+`effect` のみ。副作用は `console.log` / `console.error`。

--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: debug
+description: 3 基盤（Collector / API / Frontend）のログを CLI から横断検索する。jobNumber や URL を起点に、CloudWatch / Workers Logs / Vercel Logs を一括で引く。詳細は docs/LOGGING.md のキー名規約に依存。
+---
+
+# 横断デバッグ
+
+3 つの実行基盤のログを CLI から取得する。バラバラのダッシュボードを開かずに済ませる。
+
+## 使い方
+
+```bash
+# クローラ（CloudWatch）
+bash .claude/skills/debug/scripts/debug.sh crawler [jobNumber] [minutes]
+
+# API（Cloudflare Workers Logs / wrangler tail）
+bash .claude/skills/debug/scripts/debug.sh api [pattern] [minutes]
+
+# フロントエンド（Vercel Logs）
+bash .claude/skills/debug/scripts/debug.sh frontend [pattern] [since]
+
+# jobNumber で 3 基盤横断トレース
+bash .claude/skills/debug/scripts/debug.sh trace <jobNumber> [minutes]
+```
+
+## サブコマンド詳細
+
+### `crawler [jobNumber] [minutes=30]`
+- CloudWatch Logs `/aws/lambda/job-detail-etl` をフィルタ
+- `jobNumber` 指定時はそれを含むイベントのみ抽出
+- エラー分布 + 直近イベントを JSON で出力
+
+### `api [pattern] [minutes=15]`
+- `wrangler tail job-store --format json` でライブ取得
+- `pattern` 指定時は jq でフィルタ
+- **履歴クエリは Cloudflare ダッシュボードを参照** (Workers Logs UI)
+
+### `frontend [pattern] [since=1h]`
+- `vercel logs --since <since>` で取得
+- `pattern` 指定時は grep で絞り込み
+- 実行ディレクトリは `apps/frontend/hello-work-job-searcher` に自動切替
+
+### `trace <jobNumber> [minutes=60]`
+- 全 3 基盤を `jobNumber` で串刺し検索
+- 時系列にソートして出力
+- **前提**: 各基盤が [docs/LOGGING.md](../../../docs/LOGGING.md) の規約で `jobNumber` を構造化ログに含めていること
+
+## 前提条件
+
+| 基盤 | 必要な認証 |
+|------|----------|
+| Crawler | `AWS_PROFILE=crawler-debug` |
+| API | `wrangler login` 済み |
+| Frontend | `vercel login` 済み + `apps/frontend/hello-work-job-searcher` が Vercel プロジェクトにリンク済み |
+
+認証が切れている場合、各サブスクリプトがエラーで停止し再ログイン手順を案内する。
+
+## 個別スクリプト
+
+- `scripts/debug.sh` — ディスパッチャ
+- `scripts/debug-crawler.sh` — CloudWatch Logs クエリ
+- `scripts/debug-api.sh` — wrangler tail
+- `scripts/debug-frontend.sh` — vercel logs
+- `scripts/debug-trace.sh` — 横断トレース
+- `scripts/_check-auth.sh` — 認証チェック共通関数

--- a/.claude/skills/debug/scripts/_check-auth.sh
+++ b/.claude/skills/debug/scripts/_check-auth.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Shared auth check helpers. Source this file.
+set -euo pipefail
+
+check_aws_auth() {
+  if [ -z "${AWS_PROFILE:-}" ]; then
+    echo "ERROR: AWS_PROFILE is not set. Expected: AWS_PROFILE=crawler-debug" >&2
+    return 1
+  fi
+  if ! aws sts get-caller-identity --output json >/dev/null 2>&1; then
+    echo "ERROR: AWS auth failed for profile '$AWS_PROFILE'." >&2
+    echo "Hint: aws sso login --profile $AWS_PROFILE" >&2
+    return 1
+  fi
+}
+
+check_wrangler_auth() {
+  if ! command -v wrangler >/dev/null 2>&1; then
+    echo "ERROR: wrangler not found. Install via devbox: devbox install" >&2
+    return 1
+  fi
+  if ! wrangler whoami >/dev/null 2>&1; then
+    echo "ERROR: wrangler not authenticated." >&2
+    echo "Hint: wrangler login" >&2
+    return 1
+  fi
+}
+
+check_vercel_auth() {
+  if ! command -v vercel >/dev/null 2>&1; then
+    echo "ERROR: vercel CLI not found. Install via devbox: devbox install" >&2
+    return 1
+  fi
+  if ! vercel whoami >/dev/null 2>&1; then
+    echo "ERROR: vercel not authenticated." >&2
+    echo "Hint: vercel login" >&2
+    return 1
+  fi
+}

--- a/.claude/skills/debug/scripts/debug-api.sh
+++ b/.claude/skills/debug/scripts/debug-api.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Usage: debug-api.sh [pattern] [minutes]
+#   pattern: jq でフィルタする部分文字列（例: jobNumber、エラータグ）
+#   minutes: tail を実行する時間（デフォルト: 1 = 1分間）
+#
+# 注意: wrangler tail はライブストリームのみ。
+# 過去のログは Cloudflare ダッシュボード（Workers Logs）を参照。
+set -euo pipefail
+dir="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=/dev/null
+source "$dir/_check-auth.sh"
+check_wrangler_auth
+
+pattern="${1:-}"
+minutes="${2:-1}"
+worker="job-store"
+api_dir="$(cd "$dir/../../../../apps/backend/api" && pwd)"
+
+echo "=== Tailing $worker for ${minutes}m${pattern:+ (filter: $pattern)} ==="
+echo "Hint: 履歴クエリは Cloudflare Dashboard > Workers > $worker > Logs を参照"
+echo ""
+
+if [ -n "$pattern" ]; then
+  (cd "$api_dir" && timeout "${minutes}m" wrangler tail "$worker" --format json 2>/dev/null || true) \
+    | jq -c "select(tostring | contains(\"$pattern\"))"
+else
+  (cd "$api_dir" && timeout "${minutes}m" wrangler tail "$worker" --format json 2>/dev/null || true) \
+    | jq -c '.'
+fi

--- a/.claude/skills/debug/scripts/debug-crawler.sh
+++ b/.claude/skills/debug/scripts/debug-crawler.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Usage: debug-crawler.sh [jobNumber] [minutes_ago]
+#   jobNumber:   求人番号（指定時はこれを含むログのみ）
+#   minutes_ago: 何分前から（デフォルト: 30）
+set -euo pipefail
+dir="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=/dev/null
+source "$dir/_check-auth.sh"
+check_aws_auth
+
+job_number="${1:-}"
+minutes="${2:-30}"
+start_time=$(date -v-"${minutes}"M +%s000 2>/dev/null || date -d "${minutes} minutes ago" +%s000)
+
+filter_pattern="ERROR"
+if [ -n "$job_number" ]; then
+  filter_pattern="\"$job_number\""
+fi
+
+raw=$(aws logs filter-log-events \
+  --log-group-name /aws/lambda/job-detail-etl \
+  --start-time "$start_time" \
+  --filter-pattern "$filter_pattern" \
+  --region ap-northeast-1 \
+  --output json)
+
+count=$(echo "$raw" | jq '.events | length')
+echo "=== Hits: $count (last ${minutes}m${job_number:+, jobNumber=$job_number}) ==="
+
+if [ "$count" -eq 0 ]; then
+  exit 0
+fi
+
+echo ""
+echo "=== Error tag distribution ==="
+echo "$raw" | jq '
+  [.events[].message
+    | split("\t") | last | rtrimstr("\n")
+    | fromjson? | .errorMessage // empty
+    | capture("(?<tag>\\w+Error):")? | .tag]
+  | map(select(. != null))
+  | group_by(.) | map({error: .[0], count: length})
+  | sort_by(-.count)
+'
+
+echo ""
+echo "=== Recent events (up to 10) ==="
+echo "$raw" | jq '
+  [.events[] | {
+    timestamp: (.timestamp / 1000 | todate),
+    message: (.message | split("\t") | last | rtrimstr("\n"))
+  }] | .[-10:]
+'

--- a/.claude/skills/debug/scripts/debug-frontend.sh
+++ b/.claude/skills/debug/scripts/debug-frontend.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Usage: debug-frontend.sh [pattern] [since]
+#   pattern: grep で絞り込む部分文字列（例: jobNumber、URL）
+#   since:   vercel logs --since 形式（例: 1h, 30m, 2d）デフォルト: 1h
+set -euo pipefail
+dir="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=/dev/null
+source "$dir/_check-auth.sh"
+check_vercel_auth
+
+pattern="${1:-}"
+since="${2:-1h}"
+fe_dir="$(cd "$dir/../../../../apps/frontend/hello-work-job-searcher" && pwd)"
+
+echo "=== Vercel logs (since=$since${pattern:+, filter=$pattern}) ==="
+
+if [ -n "$pattern" ]; then
+  (cd "$fe_dir" && vercel logs --since "$since" 2>/dev/null) | grep -F "$pattern" || {
+    echo "(no matches)"
+  }
+else
+  (cd "$fe_dir" && vercel logs --since "$since" 2>/dev/null)
+fi

--- a/.claude/skills/debug/scripts/debug-trace.sh
+++ b/.claude/skills/debug/scripts/debug-trace.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Usage: debug-trace.sh <jobNumber> [minutes]
+#   jobNumber: 求人番号（必須）
+#   minutes:   何分前から（デフォルト: 60）
+#
+# 3 基盤を jobNumber で串刺し検索し、時系列にまとめる。
+# 前提: docs/LOGGING.md のキー名規約に従って jobNumber が構造化ログに含まれていること。
+set -euo pipefail
+dir="$(cd "$(dirname "$0")" && pwd)"
+
+job_number="${1:-}"
+minutes="${2:-60}"
+
+if [ -z "$job_number" ]; then
+  echo "ERROR: jobNumber is required" >&2
+  echo "Usage: debug-trace.sh <jobNumber> [minutes]" >&2
+  exit 2
+fi
+
+echo "############################################################"
+echo "# Trace for jobNumber=$job_number (last ${minutes}m)"
+echo "############################################################"
+echo ""
+
+echo "##### [1/3] Crawler (CloudWatch) #####"
+bash "$dir/debug-crawler.sh" "$job_number" "$minutes" || echo "(crawler check failed; see error above)"
+echo ""
+
+echo "##### [2/3] API (Workers) #####"
+echo "Note: wrangler tail はライブのみ。jobNumber=$job_number の履歴は"
+echo "Cloudflare Dashboard > Workers > job-store > Logs で検索してください。"
+echo ""
+
+echo "##### [3/3] Frontend (Vercel) #####"
+# vercel logs の since は h/m/d 単位
+if [ "$minutes" -ge 60 ]; then
+  since="$((minutes / 60))h"
+else
+  since="${minutes}m"
+fi
+bash "$dir/debug-frontend.sh" "$job_number" "$since" || echo "(frontend check failed; see error above)"

--- a/.claude/skills/debug/scripts/debug.sh
+++ b/.claude/skills/debug/scripts/debug.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Usage: debug.sh <subcommand> [args...]
+#   crawler  [jobNumber] [minutes]
+#   api      [pattern]   [minutes]
+#   frontend [pattern]   [since]
+#   trace    <jobNumber> [minutes]
+set -euo pipefail
+dir="$(cd "$(dirname "$0")" && pwd)"
+
+sub="${1:-}"
+shift || true
+
+case "$sub" in
+  crawler)  exec bash "$dir/debug-crawler.sh"  "$@" ;;
+  api)      exec bash "$dir/debug-api.sh"      "$@" ;;
+  frontend) exec bash "$dir/debug-frontend.sh" "$@" ;;
+  trace)    exec bash "$dir/debug-trace.sh"    "$@" ;;
+  ""|help|-h|--help)
+    cat <<'EOF'
+Usage: debug.sh <subcommand> [args...]
+
+Subcommands:
+  crawler  [jobNumber] [minutes=30]   CloudWatch Logs (job-detail-etl)
+  api      [pattern]   [minutes=15]   Cloudflare Workers (job-store)
+  frontend [pattern]   [since=1h]     Vercel Logs (frontend)
+  trace    <jobNumber> [minutes=60]   Cross-platform trace
+
+See .claude/skills/debug/SKILL.md for details.
+EOF
+    exit 0
+    ;;
+  *)
+    echo "ERROR: unknown subcommand: $sub" >&2
+    echo "Run 'debug.sh help' for usage." >&2
+    exit 2
+    ;;
+esac

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ A monorepo application for collecting, managing, and searching Hello Work (Japan
 - [docs/FRONTEND.md](docs/FRONTEND.md) — フロントエンド設計
 - [docs/QUALITY.md](docs/QUALITY.md) — テスト・品質方針
 - [docs/SECURITY.md](docs/SECURITY.md) — セキュリティ方針
+- [docs/LOGGING.md](docs/LOGGING.md) — ロギング規約（横断トレース用キー名）
 - [docs/references/conventions.md](docs/references/conventions.md) — コーディング規約・PR ルール
 
 ## Rules (パッケージスコープ)
@@ -22,6 +23,7 @@ A monorepo application for collecting, managing, and searching Hello Work (Japan
 - [.claude/rules/collector.md](.claude/rules/collector.md) — Collector 固有ルール
 - [.claude/rules/db.md](.claude/rules/db.md) — DB 固有ルール
 - [.claude/rules/models.md](.claude/rules/models.md) — Models 固有ルール
+- [.claude/rules/logger.md](.claude/rules/logger.md) — Logger 固有ルール（@sho/logger）
 - [.claude/rules/general.md](.claude/rules/general.md) — 全体共通ルール（devbox 等）
 
 ## Skills
@@ -29,6 +31,7 @@ A monorepo application for collecting, managing, and searching Hello Work (Japan
 - `/commit-and-pr` — コミット → PR 作成の自動化
 - `/pentest` — 攻撃者視点のペネトレーションテスト
 - `/crawler-diagnose` — クローラーパイプライン診断
+- `/debug` — 3 基盤横断ログ検索（CloudWatch / Workers / Vercel）
 
 ## Common Commands
 
@@ -62,4 +65,5 @@ pnpm test              # Vitest tests (PBT)
 pnpm build             # tsdown ビルド
 
 # 診断は /crawler-diagnose skill を使用
+# 横断ログ検索は /debug skill を使用
 ```

--- a/apps/backend/api/package.json
+++ b/apps/backend/api/package.json
@@ -31,6 +31,7 @@
 		"@hono/standard-validator": "^0.2.0",
 		"@hono/swagger-ui": "^0.6.0",
 		"@sho/db": "workspace:*",
+		"@sho/logger": "workspace:*",
 		"@sho/models": "workspace:*",
 		"dotenv": "^17.0.0",
 		"effect": "catalog:",

--- a/apps/backend/api/src/app/companies.ts
+++ b/apps/backend/api/src/app/companies.ts
@@ -4,6 +4,7 @@ import { Hono } from "hono";
 import { UpsertCompanyCommand } from "../cqrs/commands";
 import { FetchJobError, FindCompanyQuery } from "../cqrs/queries";
 import { JobStoreDB } from "../infra/db";
+import { LoggerLayer, logErrorCause } from "../log";
 import { verifyApiKey } from "../middleware/api-key";
 
 class InvalidJsonError extends Data.TaggedError("InvalidJsonError")<{
@@ -29,10 +30,14 @@ const app = new Hono<{ Bindings: Env }>()
       }).pipe(
         Effect.provide(FindCompanyQuery.Default),
         Effect.provideService(JobStoreDB, db),
+        Effect.tapErrorCause((cause) =>
+          logErrorCause("fetch company failed", cause).pipe(
+            Effect.annotateLogs({ establishmentNumber }),
+          ),
+        ),
         Effect.match({
           onSuccess: (company) => c.json(company),
           onFailure: (error) => {
-            console.error(error);
             switch (error._tag) {
               case "FetchJobError":
                 return c.json({ message: "Company not found" }, 404);
@@ -41,6 +46,7 @@ const app = new Hono<{ Bindings: Env }>()
             }
           },
         }),
+        Effect.provide(LoggerLayer),
       ),
     );
   })
@@ -60,6 +66,19 @@ const app = new Hono<{ Bindings: Env }>()
       }).pipe(
         Effect.provide(UpsertCompanyCommand.Default),
         Effect.provideService(JobStoreDB, db),
+        Effect.tapError((error) =>
+          error._tag === "ParseError" || error._tag === "InvalidJsonError"
+            ? Effect.logWarning("invalid company upsert request").pipe(
+                Effect.annotateLogs({
+                  _tag: error._tag,
+                  error: { message: error.message },
+                }),
+              )
+            : Effect.void,
+        ),
+        Effect.tapErrorCause((cause) =>
+          logErrorCause("upsert company failed", cause),
+        ),
         Effect.match({
           onSuccess: (result) => c.json(result),
           onFailure: (error) => {
@@ -68,11 +87,11 @@ const app = new Hono<{ Bindings: Env }>()
               case "InvalidJsonError":
                 return c.json({ message: error.message }, 400);
               default:
-                console.error(error);
                 return c.json({ message: "internal server error" }, 500);
             }
           },
         }),
+        Effect.provide(LoggerLayer),
       ),
     );
   });

--- a/apps/backend/api/src/app/jobs.ts
+++ b/apps/backend/api/src/app/jobs.ts
@@ -16,6 +16,7 @@ import {
 } from "../cqrs/queries";
 import { SearchFilterSchema } from "../cqrs/schema";
 import { JobStoreDB } from "../infra/db";
+import { LoggerLayer, logErrorCause, runLog } from "../log";
 import { verifyApiKey } from "../middleware/api-key";
 
 // --- スキーマ ---
@@ -347,13 +348,14 @@ const app = new Hono<{ Bindings: Env }>()
         }).pipe(
           Effect.provide(FetchJobsPageQuery.Default),
           Effect.provideService(JobStoreDB, db),
+          Effect.tapErrorCause((cause) =>
+            logErrorCause("fetch jobs failed", cause),
+          ),
           Effect.match({
             onSuccess: (data) => c.json(data),
-            onFailure: (error) => {
-              console.error(error);
-              return c.json({ message: "internal server error" }, 500);
-            },
+            onFailure: () => c.json({ message: "internal server error" }, 500),
           }),
+          Effect.provide(LoggerLayer),
         ),
       );
     },
@@ -368,7 +370,11 @@ const app = new Hono<{ Bindings: Env }>()
       (result, c) => {
         if (!result.success) {
           const detail = result.error.map((issue) => issue.message).join("\n");
-          console.log(`Invalid request body. detail: ${detail}`);
+          void runLog(
+            Effect.logWarning("invalid job insert request body").pipe(
+              Effect.annotateLogs({ detail }),
+            ),
+          );
           return c.json(
             { message: `Invalid request body. detail: ${detail}` },
             400,
@@ -378,7 +384,6 @@ const app = new Hono<{ Bindings: Env }>()
       },
     ),
     async (c) => {
-      console.log("in job insert route");
       const body = c.req.valid("json");
       const db = JobStoreDB.main(c.env.DB);
 
@@ -398,10 +403,14 @@ const app = new Hono<{ Bindings: Env }>()
           Effect.provide(InsertJobCommand.Default),
           Effect.provide(FindJobByNumberQuery.Default),
           Effect.provideService(JobStoreDB, db),
+          Effect.tapErrorCause((cause) =>
+            logErrorCause("insert job failed", cause).pipe(
+              Effect.annotateLogs({ jobNumber: body.jobNumber }),
+            ),
+          ),
           Effect.match({
             onSuccess: (job) => c.json(job),
             onFailure: (error) => {
-              console.error(error);
               switch (error._tag) {
                 case "InsertJobDuplicationError":
                   return c.json({ message: error.message }, 409);
@@ -414,6 +423,7 @@ const app = new Hono<{ Bindings: Env }>()
               }
             },
           }),
+          Effect.provide(LoggerLayer),
         ),
       );
     },
@@ -440,10 +450,14 @@ const app = new Hono<{ Bindings: Env }>()
         }).pipe(
           Effect.provide(FindJobByNumberQuery.Default),
           Effect.provideService(JobStoreDB, db),
+          Effect.tapErrorCause((cause) =>
+            logErrorCause("fetch job failed", cause).pipe(
+              Effect.annotateLogs({ jobNumber }),
+            ),
+          ),
           Effect.match({
             onSuccess: (job) => c.json(job),
             onFailure: (error) => {
-              console.error(error);
               switch (error._tag) {
                 case "FetchJobError":
                   return c.json({ message: "Job not found" }, 404);
@@ -452,6 +466,7 @@ const app = new Hono<{ Bindings: Env }>()
               }
             },
           }),
+          Effect.provide(LoggerLayer),
         ),
       );
     },

--- a/apps/backend/api/src/app/stats.ts
+++ b/apps/backend/api/src/app/stats.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import { describeRoute, resolver } from "hono-openapi";
 import { FetchDailyStatsQuery } from "../cqrs/queries";
 import { JobStoreDB } from "../infra/db";
+import { LoggerLayer, logErrorCause } from "../log";
 
 const dailyStatsSuccessResponseSchema = Schema.Struct({
   stats: Schema.Array(
@@ -52,13 +53,14 @@ const app = new Hono<{ Bindings: Env }>().get(
       }).pipe(
         Effect.provide(FetchDailyStatsQuery.Default),
         Effect.provideService(JobStoreDB, db),
+        Effect.tapErrorCause((cause) =>
+          logErrorCause("fetch daily stats failed", cause),
+        ),
         Effect.match({
           onSuccess: (stats) => c.json({ stats }),
-          onFailure: (error) => {
-            console.error(error);
-            return c.json({ message: "internal server error" }, 500);
-          },
+          onFailure: () => c.json({ message: "internal server error" }, 500),
         }),
+        Effect.provide(LoggerLayer),
       ),
     );
   },

--- a/apps/backend/api/src/index.ts
+++ b/apps/backend/api/src/index.ts
@@ -1,9 +1,11 @@
 import { swaggerUI } from "@hono/swagger-ui";
+import { Effect } from "effect";
 import { Hono } from "hono";
 import { openAPIRouteHandler } from "hono-openapi";
 import companies from "./app/companies";
 import jobs from "./app/jobs";
 import stats from "./app/stats";
+import { runLog } from "./log";
 import { rateLimit } from "./middleware/rate-limit";
 import { securityHeaders } from "./middleware/security-headers";
 
@@ -12,13 +14,26 @@ const app = new Hono()
   .use("*", securityHeaders)
   .use("*", async (c, next) => {
     const start = Date.now();
+    const { method, url } = c.req;
 
-    console.log(`📥 ${c.req.method} ${c.req.url}`);
+    await runLog(
+      Effect.logInfo("request started").pipe(
+        Effect.annotateLogs({ method, url }),
+      ),
+    );
 
     await next();
 
-    const duration = Date.now() - start;
-    console.log(`📤 ${c.res.status} (${duration}ms)`);
+    await runLog(
+      Effect.logInfo("request completed").pipe(
+        Effect.annotateLogs({
+          method,
+          url,
+          status: c.res.status,
+          durationMs: Date.now() - start,
+        }),
+      ),
+    );
   })
   .route("/jobs", jobs)
   .route("/companies", companies)

--- a/apps/backend/api/src/log.ts
+++ b/apps/backend/api/src/log.ts
@@ -1,0 +1,5 @@
+import { logErrorCause, makeLogger } from "@sho/logger";
+
+// @sho/logger の薄いラッパ。service=api を束縛する。
+export const { LoggerLayer, runLog } = makeLogger("api");
+export { logErrorCause };

--- a/apps/backend/collector/infra/functions/job-detail-handler/handler.ts
+++ b/apps/backend/collector/infra/functions/job-detail-handler/handler.ts
@@ -9,6 +9,7 @@ import {
   JobDetailTransformer,
   processJob,
 } from "../../../lib/job-detail-crawler";
+import { LoggerLayer, logErrorCause } from "../logger";
 import { logTmpUsage } from "../tmp-usage";
 
 // ── SQS メッセージスキーマ ──
@@ -17,26 +18,34 @@ const SqsJobMessage = Schema.Struct({
   jobNumber: Schema.String,
 });
 
+// ── /tmp クリーンアップ ──
+
+const cleanupTmp = Effect.tryPromise({
+  try: async () => {
+    for (const entry of await readdir("/tmp")) {
+      if (entry.startsWith("playwright")) {
+        await rm(`/tmp/${entry}`, { recursive: true, force: true });
+      }
+    }
+  },
+  catch: (e) => e,
+}).pipe(
+  Effect.catchAll((e) =>
+    Effect.logError("cleanup /tmp/playwright* failed").pipe(
+      Effect.annotateLogs({ error: { message: String(e) } }),
+    ),
+  ),
+);
+
 // ── processJobDetail ──
 
-const processJobDetail = async (jobNumber: string) => {
-  await Effect.gen(function* () {
+const processJobDetail = (jobNumber: string) =>
+  Effect.gen(function* () {
     const parsed = yield* Schema.decodeEither(JobNumber)(jobNumber);
     yield* processJob(parsed);
+    yield* Effect.logInfo("job detail success");
   }).pipe(
-    Effect.ensuring(
-      Effect.promise(async function cleanup() {
-        try {
-          for (const entry of await readdir("/tmp")) {
-            if (entry.startsWith("playwright")) {
-              await rm(`/tmp/${entry}`, { recursive: true, force: true });
-            }
-          }
-        } catch (e) {
-          console.log("cleanup /tmp/playwright* failed:", e);
-        }
-      }),
-    ),
+    Effect.ensuring(cleanupTmp),
     Effect.retry({
       times: 2,
       while: (e) => {
@@ -51,33 +60,34 @@ const processJobDetail = async (jobNumber: string) => {
         }
       },
     }),
+    Effect.tapErrorCause((cause) => logErrorCause("job detail failed", cause)),
+    Effect.annotateLogs({ jobNumber }),
     Effect.provide(JobDetailExtractor.Default),
     Effect.provide(JobDetailTransformer.Default),
     Effect.provide(JobDetailLoader.main),
     Effect.provide(ChromiumBrowserConfig.lambda),
+    Effect.provide(LoggerLayer),
     Effect.orDie,
-    Effect.runPromise,
   );
-  console.log(`${jobNumber} success`);
-};
 
 // ── Lambda handler ──
 
-export const handler = async (event: SQSEvent): Promise<void> => {
-  // batchSize: 1 なので Records は常に1件
-  const record = event.Records[0];
-  if (!record) {
-    console.error("No records in SQS event");
-    return;
-  }
+const handlerProgram = (event: SQSEvent) =>
+  Effect.gen(function* () {
+    // batchSize: 1 なので Records は常に1件
+    const record = event.Records[0];
+    if (!record) {
+      yield* Effect.logWarning("no records in SQS event");
+      return;
+    }
 
-  await logTmpUsage("job-detail-etl:start");
+    yield* Effect.promise(() => logTmpUsage("job-detail-etl:start"));
 
-  const parsed = Schema.decodeUnknownSync(SqsJobMessage)(
-    JSON.parse(record.body),
-  );
-  await processJobDetail(parsed.jobNumber).catch((error) => {
-    console.error(`${parsed.jobNumber} failed:`, error);
-    throw error;
-  });
-};
+    const parsed = Schema.decodeUnknownSync(SqsJobMessage)(
+      JSON.parse(record.body),
+    );
+    yield* processJobDetail(parsed.jobNumber);
+  }).pipe(Effect.provide(LoggerLayer));
+
+export const handler = async (event: SQSEvent): Promise<void> =>
+  Effect.runPromise(handlerProgram(event));

--- a/apps/backend/collector/infra/functions/job-number-handler/handler.ts
+++ b/apps/backend/collector/infra/functions/job-number-handler/handler.ts
@@ -6,44 +6,51 @@ import {
   JobNumberCrawlerConfig,
 } from "../../../lib/job-number-crawler/crawl";
 import { JobDetailQueue } from "../../sqs";
+import { LoggerLayer, logErrorCause } from "../logger";
 import { logTmpUsage } from "../tmp-usage";
 
-export const handler = async () => {
-  await logTmpUsage("job-number-crawler:start");
-
-  const jobs = await Effect.scoped(
-    Effect.gen(function* () {
-      const queue = yield* JobDetailQueue;
-      const jobs = yield* crawlJobLinks();
-      yield* Effect.forEach(jobs, (job) => queue.send(job));
-      return jobs;
-    }),
-  )
-    .pipe(
-      Effect.provide(JobNumberCrawlerConfig.main),
-      Effect.provide(ChromiumBrowserConfig.lambda),
-      Effect.provide(JobDetailQueue.Default),
-      Effect.orDie,
-      Effect.runPromise,
-    )
-    .catch((error) => {
-      console.error("crawler failed:", error);
-      throw error;
-    });
-
-  console.log(`crawler success: ${jobs.length} jobs`);
-
-  // Playwright が /tmp/playwright* にプロファイルを生成し browser.close() 後も残る。
-  // Warm Start でコンテナ再利用時に蓄積し /tmp 容量枯渇 → newPage() クラッシュの原因になると判断。
-  try {
+// Playwright が /tmp/playwright* にプロファイルを生成し browser.close() 後も残る。
+// Warm Start でコンテナ再利用時に蓄積し /tmp 容量枯渇 → newPage() クラッシュの原因になると判断。
+const cleanupTmp = Effect.tryPromise({
+  try: async () => {
     for (const entry of await readdir("/tmp")) {
       if (entry.startsWith("playwright")) {
         await rm(`/tmp/${entry}`, { recursive: true, force: true });
       }
     }
-  } catch (e) {
-    console.error("cleanup /tmp/playwright* failed", e);
-  }
+  },
+  catch: (e) => e,
+}).pipe(
+  Effect.catchAll((e) =>
+    Effect.logError("cleanup /tmp/playwright* failed").pipe(
+      Effect.annotateLogs({ error: { message: String(e) } }),
+    ),
+  ),
+);
 
+const program = Effect.gen(function* () {
+  yield* Effect.promise(() => logTmpUsage("job-number-crawler:start"));
+
+  const queue = yield* JobDetailQueue;
+  const jobs = yield* crawlJobLinks();
+  yield* Effect.forEach(jobs, (job) => queue.send(job));
+
+  yield* Effect.logInfo("job number crawler success").pipe(
+    Effect.annotateLogs({ jobCount: jobs.length }),
+  );
+
+  yield* cleanupTmp;
   return jobs;
-};
+}).pipe(
+  Effect.tapErrorCause((cause) =>
+    logErrorCause("job number crawler failed", cause),
+  ),
+  Effect.scoped,
+  Effect.provide(JobNumberCrawlerConfig.main),
+  Effect.provide(ChromiumBrowserConfig.lambda),
+  Effect.provide(JobDetailQueue.Default),
+  Effect.provide(LoggerLayer),
+  Effect.orDie,
+);
+
+export const handler = async () => Effect.runPromise(program);

--- a/apps/backend/collector/infra/functions/logger.ts
+++ b/apps/backend/collector/infra/functions/logger.ts
@@ -1,0 +1,5 @@
+import { logErrorCause, makeLogger } from "@sho/logger";
+
+// @sho/logger の薄いラッパ。service=collector を束縛する。
+export const { LoggerLayer, runLog } = makeLogger("collector");
+export { logErrorCause };

--- a/apps/backend/collector/infra/package.json
+++ b/apps/backend/collector/infra/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-sqs": "^3.800.0",
+    "@sho/logger": "workspace:*",
     "@sho/models": "workspace:*",
     "aws-cdk-lib": "2.243.0",
     "constructs": "^10.0.0",

--- a/apps/frontend/hello-work-job-searcher/package.json
+++ b/apps/frontend/hello-work-job-searcher/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@sho/api": "workspace:*",
+    "@sho/logger": "workspace:*",
     "@sho/models": "workspace:*",
     "effect": "catalog:",
     "hono": "catalog:",

--- a/apps/frontend/hello-work-job-searcher/src/app/jobs/[jobNumber]/page.tsx
+++ b/apps/frontend/hello-work-job-searcher/src/app/jobs/[jobNumber]/page.tsx
@@ -1,6 +1,8 @@
 export const dynamic = "force-dynamic";
 
+import { Effect } from "effect";
 import { jobStoreClient } from "#lib/backend-client";
+import { runLog } from "@/lib/log";
 import { JobDetailPage } from "./JobDetailPage_client";
 
 export default async function Page({
@@ -13,7 +15,11 @@ export default async function Page({
     param: { jobNumber },
   });
   if (!res.ok) {
-    console.error("Failed to fetch job detail:", res.status);
+    await runLog(
+      Effect.logError("fetch job detail failed").pipe(
+        Effect.annotateLogs({ jobNumber, status: res.status }),
+      ),
+    );
     return <div>求人情報の取得に失敗しました。</div>;
   }
   const job = await res.json();

--- a/apps/frontend/hello-work-job-searcher/src/app/jobs/page.tsx
+++ b/apps/frontend/hello-work-job-searcher/src/app/jobs/page.tsx
@@ -1,11 +1,12 @@
 export const dynamic = "force-dynamic";
 
-import { Schema } from "effect";
+import { Effect, Schema } from "effect";
 import Link from "next/link";
 import { jobStoreClient } from "#lib/backend-client";
 import { JobCard } from "@/components/features/list/JobCard";
 import { SearchFilterSchema } from "@/components/features/list/JobSearchFilter";
 import { Collapsible } from "@/components/ui/Collapsible";
+import { runLog } from "@/lib/log";
 import styles from "./JobsPageClient.module.css";
 import { JobsPagination } from "./JobsPagination_client";
 import { SearchFilterForm } from "./SearchFilterForm_client";
@@ -33,8 +34,11 @@ export default async function Page({
     },
   });
   if (!res.ok) {
-    if (process.env.NODE_ENV === "development")
-      console.error("Failed to fetch jobs:", res.status);
+    await runLog(
+      Effect.logError("fetch jobs list failed").pipe(
+        Effect.annotateLogs({ status: res.status, path: "/jobs" }),
+      ),
+    );
     return <main>求人情報の取得に失敗しました。</main>;
   }
   const data = await res.json();

--- a/apps/frontend/hello-work-job-searcher/src/lib/log.ts
+++ b/apps/frontend/hello-work-job-searcher/src/lib/log.ts
@@ -1,0 +1,6 @@
+import { logErrorCause, makeLogger } from "@sho/logger";
+
+// @sho/logger の薄いラッパ。service=frontend を束縛する。
+// RSC で console.log の出力が Vercel Logs に取り込まれる。
+export const { LoggerLayer, runLog } = makeLogger("frontend");
+export { logErrorCause };

--- a/devbox.json
+++ b/devbox.json
@@ -6,7 +6,9 @@
     "gh@2.87.3",
     "pinact@3.8.0",
     "jq@1.8.1",
-    "awscli2@2.33.2"
+    "awscli2@2.33.2",
+    "wrangler@4.62.0",
+    "nodePackages.vercel@41.4.1"
   ],
   "shell": {
     "init_hook": [

--- a/devbox.lock
+++ b/devbox.lock
@@ -233,6 +233,54 @@
         }
       }
     },
+    "nodePackages.vercel@41.4.1": {
+      "last_modified": "2026-02-03T17:56:14Z",
+      "resolved": "github:NixOS/nixpkgs/41965737c1797c1d83cfb0b644ed0840a6220bd1#nodePackages.vercel",
+      "source": "devbox-search",
+      "version": "41.4.1",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/64wx50dw8ln60js9gb79586cn59ag1v2-vercel-41.4.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/64wx50dw8ln60js9gb79586cn59ag1v2-vercel-41.4.1"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/z8yx11y1x4grsa9phxkwyhzkd60kximp-vercel-41.4.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/z8yx11y1x4grsa9phxkwyhzkd60kximp-vercel-41.4.1"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/vpflp1qzaqx0c090xj6253nzd0413sg8-vercel-41.4.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/vpflp1qzaqx0c090xj6253nzd0413sg8-vercel-41.4.1"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/5izn7nkmzd20fyj7iapbks2npix2l7ki-vercel-41.4.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/5izn7nkmzd20fyj7iapbks2npix2l7ki-vercel-41.4.1"
+        }
+      }
+    },
     "nodejs@22": {
       "last_modified": "2026-02-23T15:40:43Z",
       "plugin_version": "0.0.2",
@@ -375,6 +423,54 @@
             }
           ],
           "store_path": "/nix/store/dimsg0mxvqrc973zq0h477zfnm8mkjqw-pnpm-10.30.0"
+        }
+      }
+    },
+    "wrangler@4.62.0": {
+      "last_modified": "2026-03-27T11:17:38Z",
+      "resolved": "github:NixOS/nixpkgs/832efc09b4caf6b4569fbf9dc01bec3082a00611#wrangler",
+      "source": "devbox-search",
+      "version": "4.62.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/5zp77gv3r8ymkyiq4095ra8yg9vb4fiw-wrangler-4.62.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/5zp77gv3r8ymkyiq4095ra8yg9vb4fiw-wrangler-4.62.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/bgclh8ikwwq77czwpwmx5620qqcjif9l-wrangler-4.62.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/bgclh8ikwwq77czwpwmx5620qqcjif9l-wrangler-4.62.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/zbff62hcvs1xswy2sncayfr7n9w9iivw-wrangler-4.62.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/zbff62hcvs1xswy2sncayfr7n9w9iivw-wrangler-4.62.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/hlsn6gxdypdsfpnkqfk5z8k0lywvsmxv-wrangler-4.62.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/hlsn6gxdypdsfpnkqfk5z8k0lywvsmxv-wrangler-4.62.0"
         }
       }
     }

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -1,0 +1,111 @@
+# ロギング規約
+
+3 つの実行基盤 (Collector / API / Frontend) を横断検索可能にするための、最小限のキー名規約。
+ロガー実装は統一しない。**キー名と必須フィールドだけ統一する**。
+
+## 必須フィールド
+
+すべての構造化ログに以下を含める。
+
+| キー | 型 | 例 | 用途 |
+|------|------|------|------|
+| `service` | `"collector" \| "api" \| "frontend"` | `"api"` | 基盤識別 |
+| `level` | `"debug" \| "info" \| "warn" \| "error"` | `"error"` | 重要度 |
+| `msg` | `string` | `"job detail fetch failed"` | 人間可読サマリ |
+
+## 相関フィールド (該当する場合は必ず含める)
+
+| キー | 型 | 由来 |
+|------|------|------|
+| `jobNumber` | `string` | `13010-12345678` 形式。3 基盤横断トレースのキー |
+| `establishmentNumber` | `string` | 事業所番号 |
+| `requestId` | `string` | リクエスト単位の相関 ID (将来 OTel `trace_id` に置き換え) |
+
+**Rule of thumb**: 関数のスコープに `jobNumber` があるなら、その関数内のすべてのログに含める。
+
+## エラー固有フィールド
+
+| キー | 型 | 由来 |
+|------|------|------|
+| `_tag` | `string` | `Data.TaggedError` の `_tag`。例: `JobDetailTransformError` |
+| `error.message` | `string` | 元エラーメッセージ |
+| `error.stack` | `string?` | スタックトレース (本番では省略可) |
+
+## 実装: `@sho/logger`
+
+[packages/logger](../packages/logger/src/index.ts) が [Effect Logging](https://effect.website/docs/observability/logging/) を使った JSON ロガーを提供する。
+3 サービス (collector / api / frontend) すべてがこのパッケージに依存する。
+
+各サービスは `src/log.ts` (collector は `infra/functions/logger.ts`) で `service` を束縛した薄いラッパを公開する:
+
+```ts
+// 例: apps/backend/api/src/log.ts
+import { logErrorCause, makeLogger } from "@sho/logger";
+export const { LoggerLayer, runLog } = makeLogger("api");
+export { logErrorCause };
+```
+
+## 使い方
+
+### Effect の中
+
+```ts
+yield* Effect.logInfo("job detail success");  // service, timestamp, msg が自動付与
+
+yield* Effect.logError("job detail failed").pipe(
+  Effect.annotateLogs({ jobNumber, status: 500 }),
+);
+```
+
+### エラーハンドリング (tapErrorCause)
+
+```ts
+program.pipe(
+  Effect.tapErrorCause((cause) => logErrorCause("operation failed", cause)),
+  Effect.annotateLogs({ jobNumber }),  // この Effect 内のログすべてに付与
+  Effect.provide(LoggerLayer),
+);
+```
+
+`logErrorCause` は `Data.TaggedError` を Schema で検証して `_tag` / `error.message` を自動抽出する。
+
+### Effect の外 (Hono ミドルウェア、RSC ページ等)
+
+`runLog` で Effect をブリッジする:
+
+```ts
+await runLog(
+  Effect.logInfo("request completed").pipe(
+    Effect.annotateLogs({ method, url, status, durationMs }),
+  ),
+);
+```
+
+## アンチパターン
+
+- `console.log("failed for " + jobNumber)` — grep でキー検索できない
+- `console.error(error)` のみ — `_tag` が落ちる
+- 絵文字プレフィックス (`📥 ...`) — フィルターに使えない (人間向けの prefix は別途許容)
+
+## クエリ (横断トレース)
+
+`/debug` skill が以下を自動化する。
+
+```bash
+# jobNumber 横断検索
+.claude/skills/debug/scripts/debug.sh trace 13010-12345678
+```
+
+## 機密情報
+
+ログに以下を**含めない**:
+
+- API キー (`x-api-key` の値)
+- Cookie / Authorization ヘッダー
+- ユーザーの個人特定情報 (氏名・住所・電話番号)
+
+求人情報 (jobNumber / 求人内容) は公開情報のためログ可。
+
+## 将来の OpenTelemetry 移行
+
+`requestId` を OTel `trace_id` 形式 (16 バイト hex) で生成しておけば、後で OTel SDK を被せた時にそのまま `trace_id` として使える。

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@sho/logger",
+  "version": "1.0.0",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "scripts": {
+    "build": "pnpm exec tsdown",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "effect": "catalog:"
+  },
+  "devDependencies": {
+    "tsdown": "^0.21.0",
+    "typescript": "catalog:"
+  }
+}

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,0 +1,77 @@
+import { Cause, Effect, Logger, Schema } from "effect";
+
+// docs/LOGGING.md のキー名規約に従う Effect Logger。
+// 使い方:
+//   const { LoggerLayer, runLog } = makeLogger("api");
+//   yield* Effect.logInfo("...").pipe(Effect.annotateLogs({ jobNumber }));
+//   Effect.tapErrorCause((cause) => logErrorCause("...", cause))
+//
+// 各サービスは thin wrapper を `src/log.ts` 等に置いて
+// `service` を束縛した LoggerLayer / runLog を再エクスポートする。
+
+type Service = string;
+
+const makeJsonLogger = (service: Service) =>
+  Logger.make(({ logLevel, message, date, annotations }) => {
+    const fields: Record<string, unknown> = {};
+    for (const [key, value] of annotations) {
+      fields[key] = value;
+    }
+
+    const messages = Array.isArray(message) ? message : [message];
+    const msg = messages
+      .map((m) => (typeof m === "string" ? m : JSON.stringify(m)))
+      .join(" ");
+
+    const record: Record<string, unknown> = {
+      level: logLevel.label.toLowerCase(),
+      service,
+      timestamp: date.toISOString(),
+      msg,
+      ...fields,
+    };
+
+    if (logLevel.label === "ERROR" || logLevel.label === "WARN") {
+      console.error(JSON.stringify(record));
+    } else {
+      console.log(JSON.stringify(record));
+    }
+  });
+
+export const makeLogger = (service: Service) => {
+  const LoggerLayer = Logger.replace(
+    Logger.defaultLogger,
+    makeJsonLogger(service),
+  );
+
+  // Effect 外 (Hono ミドルウェア、RSC ページ等) から呼ぶための橋渡し。
+  const runLog = (effect: Effect.Effect<void, never, never>) =>
+    Effect.runPromise(effect.pipe(Effect.provide(LoggerLayer)));
+
+  return { LoggerLayer, runLog };
+};
+
+// Cause から _tag / error.message を抽出してエラーログを出す。
+// Effect.tapErrorCause と組み合わせて使う。service 非依存。
+const TaggedErrorShape = Schema.Struct({
+  _tag: Schema.String,
+  message: Schema.String,
+});
+
+export const logErrorCause = (msg: string, cause: Cause.Cause<unknown>) => {
+  const failure = Cause.failureOption(cause);
+  if (failure._tag === "Some") {
+    const decoded = Schema.decodeUnknownEither(TaggedErrorShape)(failure.value);
+    if (decoded._tag === "Right") {
+      return Effect.logError(msg).pipe(
+        Effect.annotateLogs({
+          _tag: decoded.right._tag,
+          error: { message: decoded.right.message },
+        }),
+      );
+    }
+  }
+  return Effect.logError(msg).pipe(
+    Effect.annotateLogs({ error: { message: Cause.pretty(cause) } }),
+  );
+};

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "noEmit": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}

--- a/packages/logger/tsdown.config.ts
+++ b/packages/logger/tsdown.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  outDir: "dist",
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  format: ["cjs", "esm"],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@sho/db':
         specifier: workspace:*
         version: link:../../../packages/db
+      '@sho/logger':
+        specifier: workspace:*
+        version: link:../../../packages/logger
       '@sho/models':
         specifier: workspace:*
         version: link:../../../packages/models
@@ -140,6 +143,9 @@ importers:
       '@aws-sdk/client-sqs':
         specifier: ^3.800.0
         version: 3.1024.0
+      '@sho/logger':
+        specifier: workspace:*
+        version: link:../../../../packages/logger
       '@sho/models':
         specifier: workspace:*
         version: link:../../../../packages/models
@@ -186,6 +192,9 @@ importers:
       '@sho/api':
         specifier: workspace:*
         version: link:../../backend/api
+      '@sho/logger':
+        specifier: workspace:*
+        version: link:../../../packages/logger
       '@sho/models':
         specifier: workspace:*
         version: link:../../../packages/models
@@ -275,6 +284,19 @@ importers:
       kysely-codegen:
         specifier: ^0.20.0
         version: 0.20.0(better-sqlite3@12.8.0)(kysely@0.28.15)(typescript@5.9.3)
+      tsdown:
+        specifier: ^0.21.0
+        version: 0.21.7(synckit@0.11.12)(typescript@5.9.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+
+  packages/logger:
+    dependencies:
+      effect:
+        specifier: 'catalog:'
+        version: 3.20.0
+    devDependencies:
       tsdown:
         specifier: ^0.21.0
         version: 0.21.7(synckit@0.11.12)(typescript@5.9.3)


### PR DESCRIPTION
## Summary

3 基盤 (collector / api / frontend) 横断の構造化ログ基盤を導入し、jobNumber 等のキーで CloudWatch / Workers Logs / Vercel Logs を横断検索できるようにする。

- packages/logger: Effect Logger ベースの JSON ロガー。makeLogger(service) で service を束縛した LoggerLayer / runLog を提供。logErrorCause は Data.TaggedError を Schema で検証して _tag / error.message を抽出。
- 各サービス: src/log.ts の薄いラッパで @sho/logger を再エクスポート。失敗ログを Effect.tapErrorCause + logErrorCause に統一。
- docs/LOGGING.md: キー名規約・アンチパターン・機密情報ルール。
- .claude/skills/debug: CLI から 3 基盤のログを横断検索するスクリプト群。debug trace <jobNumber> で串刺し検索。
- devbox.json: wrangler@4.62.0 と vercel@41.4.1 を追加。

## Test plan

- [x] pnpm -r exec tsc --noEmit が全ワークスペースで通る
- [x] pnpm --filter @sho/logger build 成功
- [x] biome format / lint 済み
- [ ] ロギング出力を実環境で目視確認 (collector: CloudWatch, api: Workers Logs, frontend: Vercel Logs)
- [ ] /debug trace <jobNumber> を実行して 3 基盤のログが串刺しヒットすること (wrangler login + vercel login + vercel link が前提)

🤖 Generated with [Claude Code](https://claude.com/claude-code)