### PR TITLE
fix(collector): @sho/logger を Lambda バンドルに含めて MODULE_NOT_FOUND を解消

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ TODO.md
 .env.sandbox
 *.tsbuildinfo
 .claude/settings.local.json
+.pnpm-store

--- a/apps/backend/collector/infra/Dockerfile
+++ b/apps/backend/collector/infra/Dockerfile
@@ -14,12 +14,14 @@ WORKDIR ${LAMBDA_TASK_ROOT}
 
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY packages/models/package.json packages/models/
+COPY packages/logger/package.json packages/logger/
 COPY apps/backend/collector/package.json apps/backend/collector/
 RUN pnpm install --frozen-lockfile
 
-# models をビルド
+# workspace パッケージをビルド
 COPY packages/models/ packages/models/
-RUN pnpm --filter @sho/models build
+COPY packages/logger/ packages/logger/
+RUN pnpm --filter @sho/models --filter @sho/logger build
 
 # collector をビルド (tsdown)
 COPY apps/backend/collector/ apps/backend/collector/

--- a/apps/backend/collector/package.json
+++ b/apps/backend/collector/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@aws-sdk/client-sqs": "^3.800.0",
     "@sho/api": "workspace:*",
+    "@sho/logger": "workspace:*",
     "@sho/models": "workspace:*",
     "@sparticuz/chromium": "^143.0.4",
     "effect": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       '@sho/api':
         specifier: workspace:*
         version: link:../api
+      '@sho/logger':
+        specifier: workspace:*
+        version: link:../../../packages/logger
       '@sho/models':
         specifier: workspace:*
         version: link:../../../packages/models


### PR DESCRIPTION
## Summary
- handler が `@sho/logger` を import しているが collector の `package.json` に未宣言、さらに Dockerfile が `packages/logger/` をコピーしていなかったため、tsdown が external 化したバンドルが Lambda 起動時に `Cannot find package '@sho/logger'` で落ちていた
- `apps/backend/collector/package.json` に `@sho/logger: workspace:*` を追加、Dockerfile に `packages/logger/` のコピーと build ステップを追加して runtime でも解決できるように
- ついでに `.pnpm-store` を `.gitignore` に追加

## 発覚経緯
- `/crawler-diagnose` で `/aws/lambda/job-number-crawler` のログを確認し、2026-04-15 16:00 UTC の cron 実行が `ERR_MODULE_NOT_FOUND` で連発していたのを検知
- commit 3a12cc3 (logger 追加) 直後の 2026-04-14 15:29 UTC デプロイ以降、壊れた状態で放置されていた

## Test plan
- [x] `pnpm --filter collector build` 成功（`dist/` に `@sho/logger` が external 参照で出力）
- [x] `pnpm --filter collector type-check` pass
- [ ] CI/CD 通過
- [ ] デプロイ後に `job-number-crawler` / `job-detail-etl` を手動 invoke して正常動作を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)