### PR TITLE
perf(collector): Lambda /tmp 圧迫を防ぐ Chromium フラグを追加

### DIFF
--- a/apps/backend/collector/lib/browser.ts
+++ b/apps/backend/collector/lib/browser.ts
@@ -32,7 +32,12 @@ export class ChromiumBrowserConfig extends Context.Tag("ChromiumBrowserConfig")<
         const { default: mod } = await import("@sparticuz/chromium");
         return {
           executablePath: await mod.executablePath(),
-          args: mod.args,
+          args: [
+            ...mod.args,
+            "--disable-gpu-shader-disk-cache",
+            "--disk-cache-size=0",
+            "--disk-cache-dir=/dev/null",
+          ],
         } satisfies LaunchOptions;
       },
       catch: (e) =>


### PR DESCRIPTION
## Summary

Lambda の `/tmp` ディスク使用量を削減するため、Chromium 起動フラグを追加。一次情報（Chromium ソース・Playwright デフォルト switches・`@sparticuz/chromium` デフォルト args）と突き合わせて検証済み。

## Background & Motivation

- Lambda の `/tmp` は 512MB 制限があり、Chromium がシェーダーキャッシュやディスクキャッシュを `/tmp` に書き込むと圧迫される
- `@sparticuz/chromium` のデフォルトでは `--disk-cache-size=33554432`（32MB）が設定されているが、クローラー用途ではキャッシュ不要

## Design Decisions

### Chromium ソースで存在を確認できたフラグのみ採用
- `--disable-gpu-shader-disk-cache`: Chromium switches リスト（Kapeli）で確認済み
- `--disk-cache-size=0`: Chromium ソース `kDiskCacheSize` で確認済み
- `--disk-cache-dir=/dev/null`: Chromium ソース `kDiskCacheDir` で確認済み

### 以下のフラグは除外
- `--disable-breakpad`, `--disable-dev-shm-usage`, `--disable-component-update`, `--disable-background-networking`: **Playwright が既にデフォルトで設定している**（`playwright-core/lib/server/chromium/chromiumSwitches.js` で確認）
- `--media-cache-size`, `--disable-crash-reporter`, `--aggressive-cache-discard`, `--disable-cache`: **Chromium ソースで存在を確認できなかった**。`--disable-breakpad` も Crashpad 移行後は無視されるとソースにコメントあり

## Changes

- `apps/backend/collector/lib/browser.ts`: `ChromiumBrowserConfig.lambda` の args に3つのフラグを追加

## Test Plan

- CI type-check・lint で確認
- Lambda デプロイ後に CloudWatch で `/tmp` 使用量を監視
