### PR TITLE
fix(collector): /tmp 枯渇と Chromium 起動エラーを解消

### DIFF
--- a/apps/backend/collector/infra/functions/job-detail-handler/handler.ts
+++ b/apps/backend/collector/infra/functions/job-detail-handler/handler.ts
@@ -1,4 +1,3 @@
-import { readdir, rm } from "node:fs/promises";
 import { JobNumber } from "@sho/models";
 import type { SQSEvent } from "aws-lambda";
 import { Effect, Schema } from "effect";
@@ -10,32 +9,13 @@ import {
   processJob,
 } from "../../../lib/job-detail-crawler";
 import { LoggerLayer, logErrorCause } from "../logger";
-import { logTmpUsage } from "../tmp-usage";
+import { cleanupTmp, disableCoreDump, logTmpUsage } from "../tmp-usage";
 
 // ── SQS メッセージスキーマ ──
 
 const SqsJobMessage = Schema.Struct({
   jobNumber: Schema.String,
 });
-
-// ── /tmp クリーンアップ ──
-
-const cleanupTmp = Effect.tryPromise({
-  try: async () => {
-    for (const entry of await readdir("/tmp")) {
-      if (entry.startsWith("playwright")) {
-        await rm(`/tmp/${entry}`, { recursive: true, force: true });
-      }
-    }
-  },
-  catch: (e) => e,
-}).pipe(
-  Effect.catchAll((e) =>
-    Effect.logError("cleanup /tmp/playwright* failed").pipe(
-      Effect.annotateLogs({ error: { message: String(e) } }),
-    ),
-  ),
-);
 
 // ── processJobDetail ──
 
@@ -81,6 +61,8 @@ const handlerProgram = (event: SQSEvent) =>
       return;
     }
 
+    yield* disableCoreDump;
+    yield* cleanupTmp;
     yield* Effect.promise(() => logTmpUsage("job-detail-etl:start"));
 
     const parsed = Schema.decodeUnknownSync(SqsJobMessage)(

--- a/apps/backend/collector/infra/functions/job-number-handler/handler.ts
+++ b/apps/backend/collector/infra/functions/job-number-handler/handler.ts
@@ -1,4 +1,3 @@
-import { readdir, rm } from "node:fs/promises";
 import { Effect } from "effect";
 import { ChromiumBrowserConfig } from "../../../lib/browser";
 import {
@@ -7,28 +6,11 @@ import {
 } from "../../../lib/job-number-crawler/crawl";
 import { JobDetailQueue } from "../../sqs";
 import { LoggerLayer, logErrorCause } from "../logger";
-import { logTmpUsage } from "../tmp-usage";
-
-// Playwright が /tmp/playwright* にプロファイルを生成し browser.close() 後も残る。
-// Warm Start でコンテナ再利用時に蓄積し /tmp 容量枯渇 → newPage() クラッシュの原因になると判断。
-const cleanupTmp = Effect.tryPromise({
-  try: async () => {
-    for (const entry of await readdir("/tmp")) {
-      if (entry.startsWith("playwright")) {
-        await rm(`/tmp/${entry}`, { recursive: true, force: true });
-      }
-    }
-  },
-  catch: (e) => e,
-}).pipe(
-  Effect.catchAll((e) =>
-    Effect.logError("cleanup /tmp/playwright* failed").pipe(
-      Effect.annotateLogs({ error: { message: String(e) } }),
-    ),
-  ),
-);
+import { cleanupTmp, disableCoreDump, logTmpUsage } from "../tmp-usage";
 
 const program = Effect.gen(function* () {
+  yield* disableCoreDump;
+  yield* cleanupTmp;
   yield* Effect.promise(() => logTmpUsage("job-number-crawler:start"));
 
   const queue = yield* JobDetailQueue;
@@ -39,9 +21,9 @@ const program = Effect.gen(function* () {
     Effect.annotateLogs({ jobCount: jobs.length }),
   );
 
-  yield* cleanupTmp;
   return jobs;
 }).pipe(
+  Effect.ensuring(cleanupTmp),
   Effect.tapErrorCause((cause) =>
     logErrorCause("job number crawler failed", cause),
   ),

--- a/apps/backend/collector/infra/functions/tmp-usage.ts
+++ b/apps/backend/collector/infra/functions/tmp-usage.ts
@@ -1,9 +1,52 @@
-import { readdir, stat, statfs } from "node:fs/promises";
+import { writeFileSync } from "node:fs";
+import { readdir, rm, stat, statfs } from "node:fs/promises";
 import { join } from "node:path";
+import { Effect } from "effect";
 
 const TMP_DIR = "/tmp";
 
 const toMB = (bytes: number) => Math.round((bytes / 1024 / 1024) * 10) / 10;
+
+// handler 開始時に呼ぶ。子プロセス（Chromium）に継承され kernel の core dump 生成を抑止する。
+// Chromium の --disable-breakpad は自前クラッシュレポーターを止めるだけで kernel が吐く core.* は別物。
+export const disableCoreDump = Effect.try({
+  try: () => writeFileSync("/proc/self/coredump_filter", "0"),
+  catch: (e) => e,
+}).pipe(
+  Effect.catchAll((e) =>
+    Effect.logWarning("disableCoreDump failed").pipe(
+      Effect.annotateLogs({
+        error:
+          e instanceof Error
+            ? { name: e.name, message: e.message, stack: e.stack }
+            : { message: String(e) },
+      }),
+    ),
+  ),
+);
+
+// core.* を対象に含めるのは Chromium のコアダンプが 1 個 1GB 級で /tmp を枯渇させるため。
+export const cleanupTmp = Effect.tryPromise({
+  try: async () => {
+    for (const entry of await readdir(TMP_DIR)) {
+      if (entry.startsWith("playwright") || entry.startsWith("core.")) {
+        await rm(join(TMP_DIR, entry), { recursive: true, force: true });
+      }
+    }
+  },
+  catch: (e) => e,
+}).pipe(
+  Effect.catchAll((e) =>
+    Effect.logError("cleanup /tmp failed").pipe(
+      Effect.annotateLogs({
+        error:
+          e instanceof Error
+            ? { name: e.name, message: e.message, stack: e.stack }
+            : { message: String(e) },
+      }),
+    ),
+  ),
+);
 
 export async function logTmpUsage(label: string): Promise<void> {
   try {

--- a/apps/backend/collector/lib/browser.ts
+++ b/apps/backend/collector/lib/browser.ts
@@ -36,7 +36,6 @@ export class ChromiumBrowserConfig extends Context.Tag("ChromiumBrowserConfig")<
             ...mod.args,
             "--disable-gpu-shader-disk-cache",
             "--disk-cache-size=0",
-            "--disk-cache-dir=/dev/null",
           ],
         } satisfies LaunchOptions;
       },


### PR DESCRIPTION
## Summary

2 件の Lambda 障害を同時に修正。

### 1. job-number-crawler の起動失敗

前回 #893 で追加した `--disk-cache-dir=/dev/null` が Chromium 起動時の mkdir を失敗させていた:

```
ERROR:../headless/lib/browser/command_line_handler.cc:154]
  Could not create directory /dev/null: File exists (17)
```

`/dev/null` は既にキャラクタデバイスとして存在するため、Chromium がディレクトリとして作成できない。`--disk-cache-size=0` でキャッシュは無効化されるので、`--disk-cache-dir` フラグは削除。

### 2. job-detail-etl の自己増殖ループ

直近 3 日間で 1013 件中 993 件が `BrowserNewPageError: context.newPage failed` で失敗。原因は Chromium クラッシュ時に kernel が吐く `core.chromium.*`（1 ファイル 1 GB 級）が `/tmp` (512 MB) を完全に埋めていた:

```
"entries":[
  {"path":"core.chromium.14","sizeMB":1033.2},
  {"path":"core.chromium.87","sizeMB":215.6},
  {"path":"chromium","sizeMB":182.1}
],
"availableMB":0
```

988 回の invocation が `availableMB:0` で開始 → Chromium が `FILE_ERROR_NO_SPACE` で即死 → また core が増える、という自己増殖。

対策:
- `/proc/self/coredump_filter=0` で kernel の core dump 生成を抑止（Chromium の `--disable-breakpad` は自前クラッシュレポーター用で OS level core dump とは別物）
- `cleanupTmp` のパターンに `core.*` を追加
- handler 開始時 `cleanupTmp` + 終了時 `Effect.ensuring(cleanupTmp)` の二段構え。Lambda timeout/OOM で ensuring を踏めず強制終了したコンテナが Warm Start で再利用されるケースに備える
- `cleanupTmp` / `disableCoreDump` を `tmp-usage.ts` に集約し両ハンドラ間の重複を解消

## Test plan

- [ ] デプロイ後 job-number-crawler が 01:00 JST の EventBridge invoke で成功する
- [ ] job-detail-etl の成功率が回復する（CloudWatch メトリクス）
- [ ] `tmpUsage` ログの `entries` に `core.*` が現れない
- [ ] 万一現れても `availableMB` が 0 にならず cleanup が効いている

🤖 Generated with [Claude Code](https://claude.com/claude-code)