### PR TITLE
fix(frontend): 絞り込みが無効化される問題を修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ TODO.md
 *.tsbuildinfo
 .claude/settings.local.json
 .pnpm-store
+.vercel
+.env*.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,26 @@ RUN apt-get update \
       gnupg \
       jq \
       unzip \
+      libglib2.0-0 \
+      libnspr4 \
+      libnss3 \
+      libatk1.0-0 \
+      libdbus-1-3 \
+      libatspi2.0-0 \
+      libx11-6 \
+      libxcomposite1 \
+      libxdamage1 \
+      libxext6 \
+      libxfixes3 \
+      libxrandr2 \
+      libgbm1 \
+      libxcb1 \
+      libxkbcommon0 \
+      libasound2 \
+      libatk-bridge2.0-0 \
+      libcups2 \
+      libcairo2 \
+      libpango-1.0-0 \
  && mkdir -p -m 755 /etc/apt/keyrings \
  && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
       -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \

--- a/apps/frontend/hello-work-job-searcher/.gitignore
+++ b/apps/frontend/hello-work-job-searcher/.gitignore
@@ -52,3 +52,4 @@ node_modules/
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+.env*.local

--- a/apps/frontend/hello-work-job-searcher/src/app/jobs/JobsPage.stories.tsx
+++ b/apps/frontend/hello-work-job-searcher/src/app/jobs/JobsPage.stories.tsx
@@ -84,3 +84,4 @@ export const Empty: Story = {
     await expect(canvas.getByText(/0 件/)).toBeInTheDocument();
   },
 };
+

--- a/apps/frontend/hello-work-job-searcher/src/app/jobs/JobsPage.stories.tsx
+++ b/apps/frontend/hello-work-job-searcher/src/app/jobs/JobsPage.stories.tsx
@@ -84,4 +84,3 @@ export const Empty: Story = {
     await expect(canvas.getByText(/0 件/)).toBeInTheDocument();
   },
 };
-

--- a/apps/frontend/hello-work-job-searcher/src/app/jobs/page.tsx
+++ b/apps/frontend/hello-work-job-searcher/src/app/jobs/page.tsx
@@ -4,7 +4,7 @@ import { Effect, Schema } from "effect";
 import Link from "next/link";
 import { jobStoreClient } from "#lib/backend-client";
 import { JobCard } from "@/components/features/list/JobCard";
-import { SearchFilterSchema } from "@/components/features/list/JobSearchFilter";
+import { SearchFilterSchema } from "@/components/features/list/JobSearchFilter.schema";
 import { Collapsible } from "@/components/ui/Collapsible";
 import { runLog } from "@/lib/log";
 import styles from "./JobsPageClient.module.css";

--- a/apps/frontend/hello-work-job-searcher/src/components/features/list/JobSearchFilter.schema.ts
+++ b/apps/frontend/hello-work-job-searcher/src/components/features/list/JobSearchFilter.schema.ts
@@ -1,0 +1,20 @@
+import { Schema } from "effect";
+
+export const SearchFilterSchema = Schema.Struct({
+  companyName: Schema.optional(Schema.String),
+  jobDescription: Schema.optional(Schema.String),
+  jobDescriptionExclude: Schema.optional(Schema.String),
+  occupation: Schema.optional(Schema.String),
+  workPlace: Schema.optional(Schema.String),
+  qualifications: Schema.optional(Schema.String),
+  employmentType: Schema.optional(Schema.String),
+  wageMin: Schema.optional(Schema.String),
+  wageMax: Schema.optional(Schema.String),
+  addedSince: Schema.optional(Schema.String),
+  addedUntil: Schema.optional(Schema.String),
+  orderByReceiveDate: Schema.optional(Schema.String),
+  onlyNotExpired: Schema.optional(Schema.String),
+  employeeCountGt: Schema.optional(Schema.String),
+  employeeCountLt: Schema.optional(Schema.String),
+});
+export type SearchFilter = Schema.Schema.Type<typeof SearchFilterSchema>;

--- a/apps/frontend/hello-work-job-searcher/src/components/features/list/JobSearchFilter.tsx
+++ b/apps/frontend/hello-work-job-searcher/src/components/features/list/JobSearchFilter.tsx
@@ -4,26 +4,13 @@ import { Schema } from "effect";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
 import { Select } from "@/components/ui/Select";
+import {
+  type SearchFilter,
+  SearchFilterSchema,
+} from "./JobSearchFilter.schema";
 import styles from "./JobSearchFilter.module.css";
 
-export const SearchFilterSchema = Schema.Struct({
-  companyName: Schema.optional(Schema.String),
-  jobDescription: Schema.optional(Schema.String),
-  jobDescriptionExclude: Schema.optional(Schema.String),
-  occupation: Schema.optional(Schema.String),
-  workPlace: Schema.optional(Schema.String),
-  qualifications: Schema.optional(Schema.String),
-  employmentType: Schema.optional(Schema.String),
-  wageMin: Schema.optional(Schema.String),
-  wageMax: Schema.optional(Schema.String),
-  addedSince: Schema.optional(Schema.String),
-  addedUntil: Schema.optional(Schema.String),
-  orderByReceiveDate: Schema.optional(Schema.String),
-  onlyNotExpired: Schema.optional(Schema.String),
-  employeeCountGt: Schema.optional(Schema.String),
-  employeeCountLt: Schema.optional(Schema.String),
-});
-export type SearchFilter = Schema.Schema.Type<typeof SearchFilterSchema>;
+export { SearchFilterSchema, type SearchFilter };
 
 export function JobSearchFilter({
   defaultValue,

--- a/apps/frontend/hello-work-job-searcher/src/components/features/list/JobSearchFilter.tsx
+++ b/apps/frontend/hello-work-job-searcher/src/components/features/list/JobSearchFilter.tsx
@@ -4,13 +4,13 @@ import { Schema } from "effect";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
 import { Select } from "@/components/ui/Select";
+import styles from "./JobSearchFilter.module.css";
 import {
   type SearchFilter,
   SearchFilterSchema,
 } from "./JobSearchFilter.schema";
-import styles from "./JobSearchFilter.module.css";
 
-export { SearchFilterSchema, type SearchFilter };
+export { type SearchFilter, SearchFilterSchema };
 
 export function JobSearchFilter({
   defaultValue,

--- a/scripts/sandbox-create.sh
+++ b/scripts/sandbox-create.sh
@@ -44,6 +44,7 @@ MOUNTS=(
 [[ -e "$HOME/.aws" ]] && MOUNTS+=( -v "$HOME/.aws:/home/node/.aws:ro" )
 
 container run -d --name "$NAME" \
+  -m 6g \
   "${MOUNTS[@]}" \
   -e GIT_AUTHOR_NAME="$GIT_NAME" \
   -e GIT_AUTHOR_EMAIL="$GIT_EMAIL" \


### PR DESCRIPTION
## Summary

- `/jobs?companyName=X` で絞り込まれず全件返ってくる問題を修正
- API 単体は正しく絞り込んでおり、原因は Frontend SSR 側
- `SearchFilterSchema` を `"use client"` 宣言の `JobSearchFilter.tsx` から export していたため、サーバーコンポーネント `page.tsx` から spread した時に空として扱われ、`companyName` 等が silent に drop されていた
- スキーマを `JobSearchFilter.schema.ts`（`"use client"` なし）に切り出して解決
- 併せて Playwright のシステム依存を Dockerfile に追加（Storybook browser mode 実行用）

## Test plan

- [x] `pnpm type-check` 通過
- [x] `pnpm vitest run` （Storybook tests）6/6 pass
- [x] `pnpm build && pnpm start` でローカル検証: `/jobs?companyName=トラスト...` が 5 件に絞られる / 入力がプリフィルされる
- [ ] production デプロイ後に同じ URL で絞り込みが効くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)