### PR TITLE
fix: 雇用形態などの enum パラメータで値ズレを型で防ぐ

### DIFF
--- a/apps/backend/api/src/app/jobs.ts
+++ b/apps/backend/api/src/app/jobs.ts
@@ -1,5 +1,11 @@
 import { Job, JobNumber } from "@sho/models";
-import { RawEmployeeCount, RawWage } from "@sho/models/raw";
+import {
+  RawEmployeeCount,
+  RawEmploymentType,
+  RawJobCategory,
+  RawWage,
+  RawWageType,
+} from "@sho/models/raw";
 import { Effect, ParseResult, Schema } from "effect";
 import { Hono } from "hono";
 import {
@@ -32,18 +38,20 @@ const SearchQueryParams = Schema.Struct({
   employeeCountGt: Schema.optional(Schema.String),
   jobDescription: Schema.optional(Schema.String),
   jobDescriptionExclude: Schema.optional(Schema.String),
-  onlyNotExpired: Schema.optional(Schema.String),
-  orderByReceiveDate: Schema.optional(Schema.String),
+  onlyNotExpired: Schema.optional(Schema.Literal("true")),
+  orderByReceiveDate: Schema.optional(
+    Schema.Union(Schema.Literal("asc"), Schema.Literal("desc")),
+  ),
   addedSince: Schema.optional(Schema.String),
   addedUntil: Schema.optional(Schema.String),
   occupation: Schema.optional(Schema.String),
-  employmentType: Schema.optional(Schema.String),
+  employmentType: Schema.optional(RawEmploymentType),
   wageMin: Schema.optional(Schema.String),
   wageMax: Schema.optional(Schema.String),
   workPlace: Schema.optional(Schema.String),
   qualifications: Schema.optional(Schema.String),
-  jobCategory: Schema.optional(Schema.String),
-  wageType: Schema.optional(Schema.String),
+  jobCategory: Schema.optional(RawJobCategory),
+  wageType: Schema.optional(RawWageType),
   education: Schema.optional(Schema.String),
   industryClassification: Schema.optional(Schema.String),
   page: Schema.optional(Schema.String),

--- a/apps/frontend/hello-work-job-searcher/src/components/features/list/JobSearchFilter.schema.ts
+++ b/apps/frontend/hello-work-job-searcher/src/components/features/list/JobSearchFilter.schema.ts
@@ -1,4 +1,9 @@
 import { Schema } from "effect";
+import {
+  RawEmploymentType,
+  RawJobCategory,
+  RawWageType,
+} from "@sho/models/raw";
 
 export const SearchFilterSchema = Schema.Struct({
   companyName: Schema.optional(Schema.String),
@@ -7,13 +12,17 @@ export const SearchFilterSchema = Schema.Struct({
   occupation: Schema.optional(Schema.String),
   workPlace: Schema.optional(Schema.String),
   qualifications: Schema.optional(Schema.String),
-  employmentType: Schema.optional(Schema.String),
+  employmentType: Schema.optional(RawEmploymentType),
+  jobCategory: Schema.optional(RawJobCategory),
+  wageType: Schema.optional(RawWageType),
   wageMin: Schema.optional(Schema.String),
   wageMax: Schema.optional(Schema.String),
   addedSince: Schema.optional(Schema.String),
   addedUntil: Schema.optional(Schema.String),
-  orderByReceiveDate: Schema.optional(Schema.String),
-  onlyNotExpired: Schema.optional(Schema.String),
+  orderByReceiveDate: Schema.optional(
+    Schema.Union(Schema.Literal("asc"), Schema.Literal("desc")),
+  ),
+  onlyNotExpired: Schema.optional(Schema.Literal("true")),
   employeeCountGt: Schema.optional(Schema.String),
   employeeCountLt: Schema.optional(Schema.String),
 });

--- a/apps/frontend/hello-work-job-searcher/src/components/features/list/JobSearchFilter.schema.ts
+++ b/apps/frontend/hello-work-job-searcher/src/components/features/list/JobSearchFilter.schema.ts
@@ -1,9 +1,9 @@
-import { Schema } from "effect";
 import {
   RawEmploymentType,
   RawJobCategory,
   RawWageType,
 } from "@sho/models/raw";
+import { Schema } from "effect";
 
 export const SearchFilterSchema = Schema.Struct({
   companyName: Schema.optional(Schema.String),

--- a/apps/frontend/hello-work-job-searcher/src/components/features/list/JobSearchFilter.tsx
+++ b/apps/frontend/hello-work-job-searcher/src/components/features/list/JobSearchFilter.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { Schema } from "effect";
+import type { hc, InferRequestType } from "hono/client";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
 import { Select } from "@/components/ui/Select";
+import type { AppType } from "@/lib/backend-client";
 import styles from "./JobSearchFilter.module.css";
 import {
   type SearchFilter,
@@ -11,6 +13,23 @@ import {
 } from "./JobSearchFilter.schema";
 
 export { type SearchFilter, SearchFilterSchema };
+
+type JobsQuery = InferRequestType<
+  ReturnType<typeof hc<AppType>>["jobs"]["$get"]
+>["query"];
+
+type EmploymentTypeValue = NonNullable<JobsQuery["employmentType"]>;
+
+const EMPLOYMENT_TYPE_OPTIONS = [
+  { value: "", label: "すべて" },
+  { value: "正社員", label: "正社員" },
+  { value: "パート労働者", label: "パート" },
+  { value: "正社員以外", label: "正社員以外" },
+  { value: "有期雇用派遣労働者", label: "派遣" },
+] as const satisfies readonly {
+  value: EmploymentTypeValue | "";
+  label: string;
+}[];
 
 export function JobSearchFilter({
   defaultValue,
@@ -40,21 +59,13 @@ export function JobSearchFilter({
         break;
     }
 
+    const raw = Object.fromEntries(
+      [...formData.entries()].filter(([, v]) => v !== ""),
+    );
+
     const parsed = Schema.decodeUnknownSync(SearchFilterSchema)({
-      companyName: formData.get("companyName"),
-      jobDescription: formData.get("jobDescription"),
-      jobDescriptionExclude: formData.get("jobDescriptionExclude"),
-      occupation: formData.get("occupation"),
-      workPlace: formData.get("workPlace"),
-      qualifications: formData.get("qualifications"),
-      employmentType: formData.get("employmentType"),
-      wageMin: formData.get("wageMin"),
-      wageMax: formData.get("wageMax"),
-      addedSince: formData.get("addedSince"),
-      addedUntil: formData.get("addedUntil"),
-      orderByReceiveDate: formData.get("orderByReceiveDate"),
-      onlyNotExpired:
-        formData.get("onlyNotExpired") === "on" ? "true" : undefined,
+      ...raw,
+      onlyNotExpired: raw.onlyNotExpired === "on" ? "true" : undefined,
       employeeCountGt,
       employeeCountLt,
     });
@@ -154,11 +165,11 @@ export function JobSearchFilter({
               aria-label="雇用形態"
               defaultValue={defaultValue.employmentType ?? ""}
             >
-              <option value="">すべて</option>
-              <option value="正社員">正社員</option>
-              <option value="パート">パート</option>
-              <option value="契約社員">契約社員</option>
-              <option value="派遣">派遣</option>
+              {EMPLOYMENT_TYPE_OPTIONS.map(({ value, label }) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
             </Select>
           </div>
           <div className={styles.fieldGroup}>


### PR DESCRIPTION
## Summary

- `/jobs?employmentType=パート` 等で API が 500 → Frontend が「取得に失敗」表示になるバグを修正
- 原因: Frontend フォームの option 値 (`パート` / `契約社員` / `派遣`) が API の `EmploymentType` 許容値 (`パート労働者` / `正社員以外` / `有期雇用派遣労働者`) とズレていた
- API 側の `SearchQueryParams` の enum フィールドを `Schema.String` から具体的な literal union に変更。これにより
  - 不正値は validator 層で 400 として返る
  - Hono RPC が literal union を client に伝播するため、Frontend で `InferRequestType<Client["jobs"]["$get"]>["query"]` から導出して `satisfies` 可能になり、値ズレがコンパイルエラーになる
- Frontend の `SearchFilterSchema` も同じ型に揃え、`InferRequestType` で derive した型で option 配列を satisfies

## Test plan

- [x] `pnpm type-check` (frontend / api) 通過
- [x] Storybook tests 6/6 pass
- [x] API Vitest 14/14 pass
- [x] `pnpm build && pnpm start` でローカル検証: `/jobs?employmentType=パート労働者` で 30 件取得
- [ ] production デプロイ後、雇用形態フィルタが動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)