### PR TITLE
feat: 求人番号のバルク存在確認で重複取得をスキップ

### DIFF
--- a/apps/backend/api/src/app/jobs.ts
+++ b/apps/backend/api/src/app/jobs.ts
@@ -18,6 +18,7 @@ import { InsertJobCommand, InsertJobDuplicationError } from "../cqrs/commands";
 import {
   FetchJobError,
   FetchJobsPageQuery,
+  FindExistingJobNumbersQuery,
   FindJobByNumberQuery,
 } from "../cqrs/queries";
 import { SearchFilterSchema } from "../cqrs/schema";
@@ -118,6 +119,19 @@ const SearchFilterQuerySchema = Schema.transformOrFail(
 );
 
 const insertJobRequestBodySchema = Job;
+
+const MAX_EXISTS_BATCH = 2000;
+
+const jobsExistsRequestBodySchema = Schema.Struct({
+  jobNumbers: Schema.Array(JobNumber).pipe(
+    Schema.minItems(1),
+    Schema.maxItems(MAX_EXISTS_BATCH),
+  ),
+});
+
+export const jobsExistsSuccessResponseSchema = Schema.Struct({
+  existing: Schema.Array(JobNumber),
+});
 
 // --- ルーティングスキーマ ---
 
@@ -319,6 +333,46 @@ const jobInsertRoute = describeRoute({
   },
 });
 
+const jobsExistsRoute = describeRoute({
+  requestBody: {
+    description: "Existence check for a list of jobNumbers",
+    required: true,
+    content: {
+      "application/json": {
+        schema: {
+          type: "object",
+          properties: {
+            jobNumbers: {
+              type: "array",
+              items: {
+                type: "string",
+                pattern: "^\\d{5}-\\d{0,8}$",
+              },
+              minItems: 1,
+              maxItems: MAX_EXISTS_BATCH,
+              description: "存在確認したい求人番号の配列",
+            },
+          },
+          required: ["jobNumbers"],
+        },
+      },
+    },
+  },
+  responses: {
+    "200": {
+      description: "Successful response",
+      content: {
+        "application/json": {
+          schema: resolver(
+            Schema.standardSchemaV1(jobsExistsSuccessResponseSchema),
+          ),
+        },
+      },
+    },
+    ...errorResponses,
+  },
+});
+
 const jobFetchRoute = describeRoute({
   responses: {
     "200": {
@@ -430,6 +484,52 @@ const app = new Hono<{ Bindings: Env }>()
                   return c.json({ message: "internal server error" }, 500);
               }
             },
+          }),
+          Effect.provide(LoggerLayer),
+        ),
+      );
+    },
+  )
+  .post(
+    "/exists",
+    jobsExistsRoute,
+    effectValidator(
+      "json",
+      Schema.standardSchemaV1(jobsExistsRequestBodySchema),
+      (result, c) => {
+        if (!result.success) {
+          const detail = result.error.map((issue) => issue.message).join("\n");
+          void runLog(
+            Effect.logWarning("invalid jobs exists request body").pipe(
+              Effect.annotateLogs({ detail }),
+            ),
+          );
+          return c.json(
+            { message: `Invalid request body. detail: ${detail}` },
+            400,
+          );
+        }
+        return undefined;
+      },
+    ),
+    (c) => {
+      const { jobNumbers } = c.req.valid("json");
+      const db = JobStoreDB.main(c.env.DB);
+
+      return Effect.runPromise(
+        Effect.gen(function* () {
+          const query = yield* FindExistingJobNumbersQuery;
+          const existing = yield* query.run(jobNumbers);
+          return { existing };
+        }).pipe(
+          Effect.provide(FindExistingJobNumbersQuery.Default),
+          Effect.provideService(JobStoreDB, db),
+          Effect.tapErrorCause((cause) =>
+            logErrorCause("find existing job numbers failed", cause),
+          ),
+          Effect.match({
+            onSuccess: (data) => c.json(data),
+            onFailure: () => c.json({ message: "internal server error" }, 500),
           }),
           Effect.provide(LoggerLayer),
         ),

--- a/apps/backend/api/src/cqrs/queries.ts
+++ b/apps/backend/api/src/cqrs/queries.ts
@@ -63,6 +63,41 @@ export class FindJobByNumberQuery extends Effect.Service<FindJobByNumberQuery>()
   },
 ) {}
 
+export class FindExistingJobNumbersQuery extends Effect.Service<FindExistingJobNumbersQuery>()(
+  "FindExistingJobNumbersQuery",
+  {
+    effect: Effect.gen(function* () {
+      const db = yield* JobStoreDB;
+      return {
+        run: (jobNumbers: readonly string[]) =>
+          Effect.tryPromise({
+            try: async (): Promise<string[]> => {
+              if (jobNumbers.length === 0) return [];
+              // D1/SQLite のパラメータ上限に備えてチャンクに分割
+              const CHUNK_SIZE = 100;
+              const existing: string[] = [];
+              for (let i = 0; i < jobNumbers.length; i += CHUNK_SIZE) {
+                const chunk = jobNumbers.slice(i, i + CHUNK_SIZE);
+                const rows = await db
+                  .selectFrom("jobs")
+                  .select("jobNumber")
+                  .where("jobNumber", "in", chunk)
+                  .execute();
+                for (const row of rows) existing.push(row.jobNumber);
+              }
+              return existing;
+            },
+            catch: (e) =>
+              new FetchJobListError({
+                message: String(e),
+                errorType: "server",
+              }),
+          }),
+      };
+    }),
+  },
+) {}
+
 export class FetchJobsPageQuery extends Effect.Service<FetchJobsPageQuery>()(
   "FetchJobsPageQuery",
   {

--- a/apps/backend/api/test/unit.spec.ts
+++ b/apps/backend/api/test/unit.spec.ts
@@ -7,7 +7,10 @@ import type { Job } from "@sho/models";
 import { Effect, Schema } from "effect";
 import { beforeAll, describe, expect, it } from "vitest";
 import worker from "../src";
-import { jobListSuccessResponseSchema } from "../src/app/jobs";
+import {
+  jobListSuccessResponseSchema,
+  jobsExistsSuccessResponseSchema,
+} from "../src/app/jobs";
 import { InsertJobCommand } from "../src/cqrs/commands";
 import { JobStoreDB } from "../src/infra/db";
 import { sampleJobs } from "./mock";
@@ -155,6 +158,62 @@ describe("求人登録", () => {
         "x-api-key": "test-api-key",
       },
       body: JSON.stringify({}),
+    });
+    expect(response.status).toBe(400);
+  });
+});
+
+// --- 求人番号の存在確認 ---
+
+describe("求人番号の存在確認", () => {
+  it("登録済みの求人番号のみが existing に含まれる", async () => {
+    const [registered, unregistered] = sampleJobs({ num: 2 });
+    await insertJob(registered);
+
+    const response = await workerFetch("/jobs/exists", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jobNumbers: [registered.jobNumber, unregistered.jobNumber],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const data = Schema.decodeUnknownSync(jobsExistsSuccessResponseSchema)(
+      await response.json(),
+    );
+    expect(data.existing).toContain(registered.jobNumber);
+    expect(data.existing).not.toContain(unregistered.jobNumber);
+  });
+
+  it("全件未登録なら existing は空配列", async () => {
+    const [job] = sampleJobs({ num: 1 });
+    const response = await workerFetch("/jobs/exists", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jobNumbers: [job.jobNumber] }),
+    });
+    expect(response.status).toBe(200);
+    const data = Schema.decodeUnknownSync(jobsExistsSuccessResponseSchema)(
+      await response.json(),
+    );
+    expect(data.existing).toEqual([]);
+  });
+
+  it("空配列は 400 を返す", async () => {
+    const response = await workerFetch("/jobs/exists", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jobNumbers: [] }),
+    });
+    expect(response.status).toBe(400);
+  });
+
+  it("不正な形式の求人番号を含むと 400 を返す", async () => {
+    const response = await workerFetch("/jobs/exists", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jobNumbers: ["invalid"] }),
     });
     expect(response.status).toBe(400);
   });

--- a/apps/backend/collector/infra/functions/job-number-handler/handler.ts
+++ b/apps/backend/collector/infra/functions/job-number-handler/handler.ts
@@ -1,5 +1,9 @@
-import { Effect } from "effect";
+import type { AppType } from "@sho/api/types";
+import type { JobNumber } from "@sho/models";
+import { Config, Data, Effect } from "effect";
+import { hc } from "hono/client";
 import { ChromiumBrowserConfig } from "../../../lib/browser";
+import type { SystemError } from "../../../lib/error";
 import {
   crawlJobLinks,
   JobNumberCrawlerConfig,
@@ -8,6 +12,61 @@ import { JobDetailQueue } from "../../sqs";
 import { LoggerLayer, logErrorCause } from "../logger";
 import { cleanupTmp, disableCoreDump, logTmpUsage } from "../tmp-usage";
 
+class JobStoreExistsError extends Data.TaggedError(
+  "JobStoreExistsError",
+)<SystemError> {}
+
+class JobStoreExistsResponseError extends Data.TaggedError(
+  "JobStoreExistsResponseError",
+)<{
+  readonly reason: string;
+  readonly status: number;
+  readonly body: string;
+}> {}
+
+const filterUnregistered = Effect.fn("filterUnregistered")(function* (
+  jobs: readonly { jobNumber: JobNumber }[],
+) {
+  if (jobs.length === 0) return jobs;
+  const endpoint = yield* Config.string("JOB_STORE_ENDPOINT");
+  const apiKey = yield* Config.string("API_KEY");
+  const client = hc<AppType>(endpoint, { headers: { "x-api-key": apiKey } });
+  const res = yield* Effect.tryPromise({
+    try: () =>
+      client.jobs.exists.$post({
+        json: { jobNumbers: jobs.map((j) => j.jobNumber) },
+      }),
+    catch: (e) =>
+      new JobStoreExistsError({
+        reason: "filterUnregistered fetch failed",
+        error: e instanceof Error ? e : new Error(String(e)),
+      }),
+  });
+  if (!res.ok) {
+    const text = yield* Effect.promise(() =>
+      res.text().catch(() => "<unreadable>"),
+    );
+    return yield* Effect.fail(
+      new JobStoreExistsResponseError({
+        reason: `jobs/exists API responded with ${res.status}`,
+        status: res.status,
+        body: text,
+      }),
+    );
+  }
+  const body = yield* Effect.promise(() => res.json());
+  const existingSet = new Set<string>(body.existing);
+  const unregistered = jobs.filter((j) => !existingSet.has(j.jobNumber));
+  yield* Effect.logInfo("filtered existing job numbers").pipe(
+    Effect.annotateLogs({
+      total: jobs.length,
+      existing: body.existing.length,
+      unregistered: unregistered.length,
+    }),
+  );
+  return unregistered;
+});
+
 const program = Effect.gen(function* () {
   yield* disableCoreDump;
   yield* cleanupTmp;
@@ -15,13 +74,17 @@ const program = Effect.gen(function* () {
 
   const queue = yield* JobDetailQueue;
   const jobs = yield* crawlJobLinks();
-  yield* Effect.forEach(jobs, (job) => queue.send(job));
+  const unregistered = yield* filterUnregistered(jobs);
+  yield* Effect.forEach(unregistered, (job) => queue.send(job));
 
   yield* Effect.logInfo("job number crawler success").pipe(
-    Effect.annotateLogs({ jobCount: jobs.length }),
+    Effect.annotateLogs({
+      crawledCount: jobs.length,
+      enqueuedCount: unregistered.length,
+    }),
   );
 
-  return jobs;
+  return unregistered;
 }).pipe(
   Effect.ensuring(cleanupTmp),
   Effect.tapErrorCause((cause) =>

--- a/apps/backend/collector/lib/job-number-crawler/crawl.ts
+++ b/apps/backend/collector/lib/job-number-crawler/crawl.ts
@@ -196,7 +196,7 @@ export class JobNumberCrawlerConfig extends Effect.Tag(
       },
     },
     nextPageDelayMs: 3000,
-    roughMaxCount: 1000,
+    roughMaxCount: 2000,
   });
   static dev = Layer.succeed(JobNumberCrawlerConfig, {
     jobSearchCriteria: {


### PR DESCRIPTION
## Summary
- API に `POST /jobs/exists` を追加。`{ jobNumbers: [...] }` を受け取り、DB に登録済みの jobNumber 集合を返す（最大 2000 件、チャンク 100 件で IN 照会）。
- 求人番号クローラー（job-number-handler Lambda）をクロール完了後に `/jobs/exists` でバッチ照会し、未登録分だけ SQS に投入するよう変更。
- クローラーの `roughMaxCount` を 1000 → 2000 に引き上げ。

## Test plan
- [x] API: `pnpm --filter @sho/api type-check`
- [x] API: `pnpm --filter @sho/api test`（18 tests passed、新規 4 ケース含む）
- [x] Collector: `pnpm --filter collector type-check`
- [x] Collector: `pnpm --filter collector test`
- [ ] ステージングで job-number-handler を手動 invoke して `crawledCount` / `enqueuedCount` がログに出ることを確認
- [ ] 2 回目の invoke で `enqueuedCount` が 0 近傍になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)