### PR TITLE
refactor(frontend): 求人一覧を Suspense 化し、お気に入り空状態を追加

### DIFF
--- a/apps/frontend/hello-work-job-searcher/src/app/favorites/page.module.css
+++ b/apps/frontend/hello-work-job-searcher/src/app/favorites/page.module.css
@@ -4,7 +4,6 @@
 
 .mainSection {
   padding: 2rem 0;
-  background: var(--color-bg-page);
   min-height: 100vh;
 }
 

--- a/apps/frontend/hello-work-job-searcher/src/app/jobs/JobsList.stories.tsx
+++ b/apps/frontend/hello-work-job-searcher/src/app/jobs/JobsList.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Suspense } from "react";
+import { expect, within } from "storybook/test";
+import { mockJobs } from "@/lib/backend-client.mock";
+import { JobsList, type JobsListData } from "./JobsList_client";
+import { JobsListSkeleton } from "./JobsListSkeleton";
+
+const filterParams = new URLSearchParams();
+
+const listData: JobsListData = {
+  jobs: mockJobs.slice(0, 5) as unknown as JobsListData["jobs"],
+  meta: { totalCount: mockJobs.length, page: 1, totalPages: 2 },
+};
+
+const meta = {
+  title: "Pages/JobsPage/JobsList",
+  component: JobsList,
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+      navigation: { pathname: "/jobs" },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <Suspense fallback={<JobsListSkeleton />}>
+        <Story />
+      </Suspense>
+    ),
+  ],
+} satisfies Meta<typeof JobsList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    jobsPromise: Promise.resolve(listData),
+    filterParams,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/25 件/)).toBeInTheDocument();
+    await expect(
+      canvas.getAllByText(mockJobs[0].occupation).length,
+    ).toBeGreaterThan(0);
+  },
+};
+
+export const LoadingState: Story = {
+  name: "Loading (Suspense fallback)",
+  args: {
+    jobsPromise: new Promise<JobsListData>(() => {}),
+    filterParams,
+  },
+};

--- a/apps/frontend/hello-work-job-searcher/src/app/jobs/JobsListSkeleton.tsx
+++ b/apps/frontend/hello-work-job-searcher/src/app/jobs/JobsListSkeleton.tsx
@@ -1,0 +1,49 @@
+import { Card } from "@/components/ui/Card";
+import { Skeleton } from "@/components/ui/skeleton";
+import styles from "./JobsPageClient.module.css";
+
+const SKELETON_IDS = ["a", "b", "c", "d", "e"] as const;
+
+function JobCardSkeleton() {
+  return (
+    <Card className={styles.cardSkeleton}>
+      <Skeleton className={styles.cardSkeletonTitle} />
+      <div className={styles.cardSkeletonDetails}>
+        <Skeleton
+          className={styles.cardSkeletonLine}
+          style={{ width: "60%" }}
+        />
+        <Skeleton
+          className={styles.cardSkeletonLine}
+          style={{ width: "50%" }}
+        />
+        <Skeleton
+          className={styles.cardSkeletonLine}
+          style={{ width: "70%" }}
+        />
+        <Skeleton
+          className={styles.cardSkeletonLine}
+          style={{ width: "45%" }}
+        />
+      </div>
+    </Card>
+  );
+}
+
+export function JobsListSkeleton() {
+  return (
+    <>
+      <div className={styles.totalCountSkeleton}>
+        求人情報の総数:
+        <Skeleton className={styles.totalCountNumberSkeleton} />件
+      </div>
+      <div className={styles.items}>
+        {SKELETON_IDS.map((id) => (
+          <div key={id} className={styles.cardLink}>
+            <JobCardSkeleton />
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/apps/frontend/hello-work-job-searcher/src/app/jobs/JobsList_client.tsx
+++ b/apps/frontend/hello-work-job-searcher/src/app/jobs/JobsList_client.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import type { hc, InferResponseType } from "hono/client";
+import Link from "next/link";
+import { use } from "react";
+import { JobCard } from "@/components/features/list/JobCard";
+import type { AppType } from "@/lib/backend-client";
+import styles from "./JobsPageClient.module.css";
+import { JobsPagination } from "./JobsPagination_client";
+
+export type JobsListData = InferResponseType<
+  ReturnType<typeof hc<AppType>>["jobs"]["$get"],
+  200
+>;
+
+export function JobsList({
+  jobsPromise,
+  filterParams,
+}: {
+  jobsPromise: Promise<JobsListData>;
+  filterParams: URLSearchParams;
+}) {
+  const data = use(jobsPromise);
+  const { page, totalPages, totalCount } = data.meta;
+
+  return (
+    <>
+      <div>求人情報の総数: {totalCount} 件</div>
+      {totalPages > 1 && (
+        <JobsPagination
+          currentPage={page}
+          totalPages={totalPages}
+          filterParams={filterParams}
+        />
+      )}
+      <div className={styles.items}>
+        {data.jobs.map((job) => {
+          const isNew =
+            !!job.receivedDate &&
+            Date.now() - new Date(job.receivedDate).getTime() <=
+              3 * 24 * 60 * 60 * 1000;
+          return (
+            <Link
+              key={job.jobNumber}
+              href={`/jobs/${job.jobNumber}`}
+              className={styles.cardLink}
+            >
+              <JobCard job={job} isNew={isNew} />
+            </Link>
+          );
+        })}
+      </div>
+      {totalPages > 1 && (
+        <JobsPagination
+          currentPage={page}
+          totalPages={totalPages}
+          filterParams={filterParams}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/frontend/hello-work-job-searcher/src/app/jobs/JobsPageClient.module.css
+++ b/apps/frontend/hello-work-job-searcher/src/app/jobs/JobsPageClient.module.css
@@ -9,6 +9,7 @@
 .header {
   flex: none;
   padding: 1rem 1.5rem;
+  margin-bottom: 1rem;
   border-bottom: 1px solid var(--color-border);
   display: flex;
   flex-direction: column;
@@ -50,6 +51,40 @@
   padding: 0.1rem 0.6rem;
   font-weight: 700;
   display: inline-block;
+}
+
+.totalCountSkeleton {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.totalCountNumberSkeleton {
+  display: inline-block;
+  width: 2.5rem;
+  height: 1rem;
+}
+
+.cardSkeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.25rem 1.5rem;
+}
+
+.cardSkeletonTitle {
+  width: 40%;
+  height: 1rem;
+}
+
+.cardSkeletonDetails {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.cardSkeletonLine {
+  height: 0.9rem;
 }
 
 @media (max-width: 768px) {

--- a/apps/frontend/hello-work-job-searcher/src/app/jobs/loading.tsx
+++ b/apps/frontend/hello-work-job-searcher/src/app/jobs/loading.tsx
@@ -1,6 +1,13 @@
-import Loading from "@/components/ui/Loading";
+import { JobsListSkeleton } from "./JobsListSkeleton";
+import styles from "./JobsPageClient.module.css";
 
-export default function Page() {
-  // Or a custom loading skeleton component
-  return <Loading />;
+export default function Loading() {
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <h1 className={styles.title}>求人情報一覧</h1>
+      </div>
+      <JobsListSkeleton />
+    </div>
+  );
 }

--- a/apps/frontend/hello-work-job-searcher/src/app/jobs/page.tsx
+++ b/apps/frontend/hello-work-job-searcher/src/app/jobs/page.tsx
@@ -1,14 +1,14 @@
 export const dynamic = "force-dynamic";
 
 import { Effect, Schema } from "effect";
-import Link from "next/link";
+import { Suspense } from "react";
 import { jobStoreClient } from "#lib/backend-client";
-import { JobCard } from "@/components/features/list/JobCard";
 import { SearchFilterSchema } from "@/components/features/list/JobSearchFilter.schema";
 import { Collapsible } from "@/components/ui/Collapsible";
 import { runLog } from "@/lib/log";
+import { JobsList } from "./JobsList_client";
+import { JobsListSkeleton } from "./JobsListSkeleton";
 import styles from "./JobsPageClient.module.css";
-import { JobsPagination } from "./JobsPagination_client";
 import { SearchFilterForm } from "./SearchFilterForm_client";
 
 const SearchParams = Schema.Struct({
@@ -25,24 +25,26 @@ export default async function Page({
   const { page: pageStr, ...filter } =
     Schema.decodeUnknownSync(SearchParams)(raw);
 
-  const res = await jobStoreClient.jobs.$get({
-    query: {
-      ...filter,
-      onlyNotExpired: filter.onlyNotExpired === "true" ? "true" : undefined,
-      orderByReceiveDate: filter.orderByReceiveDate ?? ("desc" as const),
-      page: pageStr ?? "1",
-    },
-  });
-  if (!res.ok) {
-    await runLog(
-      Effect.logError("fetch jobs list failed").pipe(
-        Effect.annotateLogs({ status: res.status, path: "/jobs" }),
-      ),
-    );
-    return <main>求人情報の取得に失敗しました。</main>;
-  }
-  const data = await res.json();
-  const { page, totalPages, totalCount } = data.meta;
+  const jobsPromise = (async () => {
+    const res = await jobStoreClient.jobs.$get({
+      query: {
+        ...filter,
+        onlyNotExpired: filter.onlyNotExpired === "true" ? "true" : undefined,
+        orderByReceiveDate: filter.orderByReceiveDate ?? ("desc" as const),
+        page: pageStr ?? "1",
+      },
+    });
+    if (!res.ok) {
+      await runLog(
+        Effect.logError("fetch jobs list failed").pipe(
+          Effect.annotateLogs({ status: res.status, path: "/jobs" }),
+        ),
+      );
+      throw new Error(`fetch jobs list failed: ${res.status}`);
+    }
+    return await res.json();
+  })();
+
   const hasFilter =
     !!filter.companyName ||
     !!filter.jobDescription ||
@@ -89,42 +91,13 @@ export default async function Page({
     <div className={styles.container}>
       <div className={styles.header}>
         <h1 className={styles.title}>求人情報一覧</h1>
-        <div>求人情報の総数: {totalCount} 件</div>
         <Collapsible title="絞り込み" defaultOpen={hasFilter}>
           <SearchFilterForm defaultValue={filter} />
         </Collapsible>
       </div>
-      {totalPages > 1 && (
-        <JobsPagination
-          currentPage={page}
-          totalPages={totalPages}
-          filterParams={filterParams}
-        />
-      )}
-      <div className={styles.items}>
-        {data.jobs.map((job) => {
-          const isNew =
-            !!job.receivedDate &&
-            Date.now() - new Date(job.receivedDate).getTime() <=
-              3 * 24 * 60 * 60 * 1000;
-          return (
-            <Link
-              key={job.jobNumber}
-              href={`/jobs/${job.jobNumber}`}
-              className={styles.cardLink}
-            >
-              <JobCard job={job} isNew={isNew} />
-            </Link>
-          );
-        })}
-      </div>
-      {totalPages > 1 && (
-        <JobsPagination
-          currentPage={page}
-          totalPages={totalPages}
-          filterParams={filterParams}
-        />
-      )}
+      <Suspense fallback={<JobsListSkeleton />}>
+        <JobsList jobsPromise={jobsPromise} filterParams={filterParams} />
+      </Suspense>
     </div>
   );
 }

--- a/apps/frontend/hello-work-job-searcher/src/components/features/favorites/JobFavoriteList.module.css
+++ b/apps/frontend/hello-work-job-searcher/src/components/features/favorites/JobFavoriteList.module.css
@@ -40,3 +40,34 @@
   color: inherit;
   display: block;
 }
+
+.emptyState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 3rem 1rem;
+  color: var(--color-text-muted);
+}
+
+.emptyMessage {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.emptyCta {
+  color: var(--color-accent);
+  text-decoration: none;
+  font-weight: 600;
+  padding: 0.5rem 1.25rem;
+  border: 1px solid var(--color-accent);
+  border-radius: var(--radius-sm);
+  transition:
+    background var(--transition-normal),
+    color var(--transition-normal);
+}
+
+.emptyCta:hover {
+  background: var(--color-accent);
+  color: var(--color-bg-surface);
+}

--- a/apps/frontend/hello-work-job-searcher/src/components/features/favorites/JobFavoriteList.tsx
+++ b/apps/frontend/hello-work-job-searcher/src/components/features/favorites/JobFavoriteList.tsx
@@ -34,6 +34,17 @@ export function FavoriteJobOverviewList() {
     }
   }, [setFavorites]);
 
+  if (items.length === 0) {
+    return (
+      <div className={styles.emptyState}>
+        <p className={styles.emptyMessage}>お気に入りはまだありません</p>
+        <Link href="/jobs" className={styles.emptyCta}>
+          求人情報を探す
+        </Link>
+      </div>
+    );
+  }
+
   return (
     <CardGroup>
       {items.map((item) => (

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -13,6 +13,8 @@
 ## 状態管理
 
 - **求人データ**: RSC で API から取得。URL searchParams が Source of Truth（フィルター・ページネーション）
+  - `/jobs` は Suspense + `use(jobsPromise)` でストリーミング（shell はヘッダ + フィルターフォーム、リストは `<JobsListSkeleton />` を fallback にしてロード）
+  - 失敗時は `error.tsx` がキャッチ
 - **お気に入り**: Jotai + localStorage（`atom.ts` に Source of Truth / Selectors / Writers を集約）
 
 ## UI コンポーネント (`src/components/ui/`)


### PR DESCRIPTION
## Summary
- `/jobs` を Suspense + `use(jobsPromise)` 化。ヘッダ・フィルタは即時描画、リストは `JobsListSkeleton` を fallback に段階描画。
- `/favorites` に空状態 (メッセージ + `/jobs` への CTA) を追加し、`--color-bg-page` 由来の gray 背景を白に戻した。

## Background & Motivation
- `/jobs` はこれまで `await jobStoreClient.jobs.$get()` でデータ取得完了までページ全体の描画がブロックされていた。体感レイテンシを下げつつ、スピナーより情報量のある skeleton を出したい。
- `/favorites` の Empty ストーリーを開くとタイトル以外が白紙で、未登録であることが伝わらなかった。また favorites ページの背景 `--color-bg-page` (#f8f9fa) が他ページと異なって gray に見えていた。

## Design Decisions
- **サーバで `res.ok` を解決してから client へ Promise を渡す**: `Response` は RSC 境界を越えられないので、page.tsx 側の async IIFE で JSON を取り出してから `jobsPromise: Promise<JobsListData>` を `"use client"` の `JobsList` に渡す。失敗時は `throw` で Next.js の `error.tsx` が拾う。`null` 返却で client 側に失敗 UI を持たせる案は却下 (エラーハンドリングが分散する)。
- **Suspense 境界は 1 個だけ**: ヘッダと総数・リストを 2 境界で分ける案もあったが、いずれも同じ promise を await するため遅延効果はなく、複雑さを増すだけ。総数 (`求人情報の総数: N 件`) は suspended 側へ移動し、skeleton で「求人情報の総数: [bar] 件」の形に。
- **skeleton のキー**: ループの key に index を使うと biome が警告するため、`["a","b","c","d","e"]` の静的配列を採用。カード数を可変にする needs は現時点で無いため引数化しない。
- **お気に入り空状態**: アイコンなしのシンプルなメッセージ + CTA リンク。将来デザイン強化する余地は残しつつ、現在の他ページと整合するミニマムに留めた。
- **背景 gray の是非**: `--color-bg-page` は `#f8f9fa` で意図的な token だが、`/jobs` など他ページは設定していない。一貫性を優先して favorites の `.mainSection` からも外した。

## Changes
### `apps/frontend/hello-work-job-searcher/src/app/jobs/`
- `page.tsx`: `jobStoreClient.jobs.$get()` を async IIFE にインライン化し `await` しない。`res.ok` なら JSON、失敗なら `runLog` + `throw`。Suspense で `<JobsList jobsPromise=... />` を包む。
- `JobsList_client.tsx` (新規): `"use client"` + `use(jobsPromise)`。総数テキスト・ページネーション・カードリストを描画。
- `JobsListSkeleton.tsx` (新規): 総数行 (テキスト + 数字の inline skeleton) と 5 枚のカード skeleton。
- `JobsList.stories.tsx` (新規): `Default` / `LoadingState` (never-resolving promise) の 2 ストーリー。
- `JobsPageClient.module.css`: skeleton 用クラス追加 + `.header` に `margin-bottom: 1rem`。
- `loading.tsx`: `<Loading />` (スピナー) → タイトル + `<JobsListSkeleton />`。

### `apps/frontend/hello-work-job-searcher/src/app/favorites/`
- `page.module.css`: `.mainSection` から `background: var(--color-bg-page)` を削除。

### `apps/frontend/hello-work-job-searcher/src/components/features/favorites/`
- `JobFavoriteList.tsx`: `items.length === 0` のときメッセージ + CTA を表示する分岐を追加。
- `JobFavoriteList.module.css`: `.emptyState` / `.emptyMessage` / `.emptyCta` を追加。

### `docs/FRONTEND.md`
- 状態管理セクションに「`/jobs` は Suspense + `use(jobsPromise)` でストリーミング、エラーは `error.tsx`」を追記。

## Test Plan
- [x] `pnpm exec biome check --write` で対象ファイルを format/lint。
- [x] `pnpm type-check` 成功。
- [ ] Storybook で `Pages/JobsPage/JobsList/Default` / `Loading (Suspense fallback)` を目視確認。
- [ ] Storybook で `Pages/JobsPage/Loading/Default` が skeleton 表示されること。
- [ ] Storybook で `Pages/FavoritesPage/Empty` に空状態メッセージ + CTA が出ること。
- [ ] `pnpm dev` で `/jobs` 初回アクセス時にヘッダ即描画 → リスト skeleton → 実データ差し替えを確認。
- [ ] API 側で 500 を返させて `error.tsx` が表示されることを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
