### PR TITLE
refactor(frontend): 事業所詳細に loading.tsx を追加しページネーションで Suspense を発火

### DIFF
--- a/apps/frontend/hello-work-job-searcher/src/app/companies/[establishmentNumber]/CompanyDetailLoading.stories.tsx
+++ b/apps/frontend/hello-work-job-searcher/src/app/companies/[establishmentNumber]/CompanyDetailLoading.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import Loading from "./loading";
+
+const meta = {
+  title: "Pages/CompanyDetailPage/Loading",
+  component: Loading,
+} satisfies Meta<typeof Loading>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/apps/frontend/hello-work-job-searcher/src/app/companies/[establishmentNumber]/CompanyDetailPage.module.css
+++ b/apps/frontend/hello-work-job-searcher/src/app/companies/[establishmentNumber]/CompanyDetailPage.module.css
@@ -101,6 +101,38 @@
   color: var(--color-text-muted, #666);
 }
 
+.titleSkeleton {
+  display: inline-block;
+  width: 14rem;
+  height: 1.1rem;
+}
+
+.subtitleSkeleton {
+  display: inline-block;
+  width: 8rem;
+  height: 0.7rem;
+  vertical-align: middle;
+}
+
+.valueSkeleton {
+  display: inline-block;
+  width: 60%;
+  min-width: 8rem;
+  height: 0.9rem;
+}
+
+.jobOccupationSkeleton {
+  width: 40%;
+  min-width: 10rem;
+  height: 1rem;
+}
+
+.jobMetaSkeleton {
+  width: 30%;
+  min-width: 8rem;
+  height: 0.8rem;
+}
+
 @media (max-width: 768px) {
   .header {
     padding: 0.75rem 1rem 0;

--- a/apps/frontend/hello-work-job-searcher/src/app/companies/[establishmentNumber]/CompanyDetailSkeleton.tsx
+++ b/apps/frontend/hello-work-job-searcher/src/app/companies/[establishmentNumber]/CompanyDetailSkeleton.tsx
@@ -1,0 +1,48 @@
+import { Label } from "@/components/ui/Label";
+import { Skeleton } from "@/components/ui/skeleton";
+import styles from "./CompanyDetailPage.module.css";
+
+const LABEL_TERMS = [
+  "会社名",
+  "郵便番号",
+  "所在地",
+  "従業員数",
+  "設立年",
+  "資本金",
+  "事業内容",
+  "法人番号",
+] as const;
+
+const JOB_SKELETON_IDS = ["a", "b", "c"] as const;
+
+export function CompanyDetailSkeleton() {
+  return (
+    <article className={styles.article}>
+      <h2 className={styles.title}>
+        <Skeleton className={styles.titleSkeleton} />
+        <span className={styles.subtitle}>
+          事業所番号: <Skeleton className={styles.subtitleSkeleton} />
+        </span>
+      </h2>
+      <div className={styles.labels}>
+        {LABEL_TERMS.map((term) => (
+          <Label key={term} term={term}>
+            <Skeleton className={styles.valueSkeleton} />
+          </Label>
+        ))}
+      </div>
+
+      <h3 className={styles.jobsHeading}>この事業所の求人</h3>
+      <ul className={styles.jobs}>
+        {JOB_SKELETON_IDS.map((id) => (
+          <li key={id} className={styles.jobItem}>
+            <div className={styles.jobLink}>
+              <Skeleton className={styles.jobOccupationSkeleton} />
+              <Skeleton className={styles.jobMetaSkeleton} />
+            </div>
+          </li>
+        ))}
+      </ul>
+    </article>
+  );
+}

--- a/apps/frontend/hello-work-job-searcher/src/app/companies/[establishmentNumber]/loading.tsx
+++ b/apps/frontend/hello-work-job-searcher/src/app/companies/[establishmentNumber]/loading.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
-import { CompanyDetailSkeleton } from "./CompanyDetailSkeleton";
 import styles from "./CompanyDetailPage.module.css";
+import { CompanyDetailSkeleton } from "./CompanyDetailSkeleton";
 
 export default function Loading() {
   return (

--- a/apps/frontend/hello-work-job-searcher/src/app/companies/[establishmentNumber]/loading.tsx
+++ b/apps/frontend/hello-work-job-searcher/src/app/companies/[establishmentNumber]/loading.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+import { CompanyDetailSkeleton } from "./CompanyDetailSkeleton";
+import styles from "./CompanyDetailPage.module.css";
+
+export default function Loading() {
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <Link href="/jobs" className={styles.backLink}>
+          &larr; 求人一覧に戻る
+        </Link>
+      </div>
+      <CompanyDetailSkeleton />
+    </div>
+  );
+}

--- a/apps/frontend/hello-work-job-searcher/src/app/jobs/JobsList_client.tsx
+++ b/apps/frontend/hello-work-job-searcher/src/app/jobs/JobsList_client.tsx
@@ -37,6 +37,7 @@ export function JobsList({
             <Link
               key={job.jobNumber}
               href={`/jobs/${job.jobNumber}`}
+              prefetch={true}
               className={styles.cardLink}
             >
               <JobCard job={job} isNew={isNew} />

--- a/apps/frontend/hello-work-job-searcher/src/app/jobs/page.tsx
+++ b/apps/frontend/hello-work-job-searcher/src/app/jobs/page.tsx
@@ -25,6 +25,8 @@ export default async function Page({
   const { page: pageStr, ...filter } =
     Schema.decodeUnknownSync(SearchParams)(raw);
 
+  const suspenseKey = JSON.stringify({ page: pageStr ?? "1", ...filter });
+
   const jobsPromise = (async () => {
     const res = await jobStoreClient.jobs.$get({
       query: {
@@ -70,7 +72,7 @@ export default async function Page({
           <SearchFilterForm defaultValue={filter} />
         </Collapsible>
       </div>
-      <Suspense fallback={<JobsListSkeleton />}>
+      <Suspense key={suspenseKey} fallback={<JobsListSkeleton />}>
         <JobsList jobsPromise={jobsPromise} />
       </Suspense>
     </div>


### PR DESCRIPTION
## Summary
- 事業所詳細ページに `loading.tsx` + `CompanyDetailSkeleton` を追加（会社情報ラベル 8 個 + 求人リスト 3 件分の skeleton）
- 求人カードの `Link` に `prefetch={true}` を明示。Next.js の Link は viewport 内に入ったものだけ IntersectionObserver で実際に prefetch するため、見える分だけ RSC payload が前読みされる
- 求人一覧の `<Suspense>` に searchParams 由来の `key` を付与。React 19 は transition 中に fallback を出さず古い UI を保つ仕様のため、key で強制再マウントしてページネーション時に skeleton が出るようにした

## Test plan
- [ ] `/companies/[establishmentNumber]` にアクセスした瞬間に skeleton が出る
- [ ] 求人一覧のページネーション（前へ/次へ/数字）をクリックすると skeleton が一瞬挟まる
- [ ] 求人カードの Link が viewport に入ったタイミングで prefetch される（DevTools Network で `?_rsc=...` が飛ぶ）
- [ ] `pnpm type-check` / `pnpm lint` / `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)