### PR TITLE
refactor(collector): 求人番号クローラーを Stream 化しページ単位に分離

### DIFF
--- a/apps/backend/collector/infra/functions/job-number-handler/handler.ts
+++ b/apps/backend/collector/infra/functions/job-number-handler/handler.ts
@@ -1,9 +1,10 @@
-import { Effect } from "effect";
+import { Effect, Ref, Stream } from "effect";
 import { APIConfig } from "../../../lib/apiClient/config";
+import { filterUnregistered } from "../../../lib/apiClient/query";
 import { ChromiumBrowserConfig } from "../../../lib/browser";
 import {
-  crawlJobLinks,
   JobNumberCrawlerConfig,
+  paginatedJobNumbers,
 } from "../../../lib/job-number-crawler/crawl";
 import { JobDetailQueue } from "../../sqs";
 import { LoggerLayer, logErrorCause } from "../logger";
@@ -15,16 +16,26 @@ const program = Effect.gen(function* () {
   yield* Effect.promise(() => logTmpUsage("job-number-crawler:start"));
 
   const queue = yield* JobDetailQueue;
-  const jobs = yield* crawlJobLinks();
-  yield* Effect.forEach(jobs, (jobNumber) => queue.send({ jobNumber }));
+  const enqueuedCountRef = yield* Ref.make(0);
 
-  yield* Effect.logInfo("job number crawler success").pipe(
-    Effect.annotateLogs({
-      enqueuedCount: jobs.length,
-    }),
+  yield* paginatedJobNumbers().pipe(
+    Stream.runForEach((jobNumbers) =>
+      Effect.gen(function* () {
+        const unregistered = yield* filterUnregistered(jobNumbers);
+        yield* Effect.forEach(unregistered, (jobNumber) =>
+          queue.send({ jobNumber }),
+        );
+        yield* Ref.update(enqueuedCountRef, (n) => n + unregistered.length);
+      }),
+    ),
   );
 
-  return jobs;
+  const enqueuedCount = yield* Ref.get(enqueuedCountRef);
+  yield* Effect.logInfo("job number crawler success").pipe(
+    Effect.annotateLogs({ enqueuedCount }),
+  );
+
+  return enqueuedCount;
 }).pipe(
   Effect.ensuring(cleanupTmp),
   Effect.tapErrorCause((cause) =>

--- a/apps/backend/collector/infra/functions/job-number-handler/handler.ts
+++ b/apps/backend/collector/infra/functions/job-number-handler/handler.ts
@@ -10,6 +10,8 @@ import { JobDetailQueue } from "../../sqs";
 import { LoggerLayer, logErrorCause } from "../logger";
 import { cleanupTmp, disableCoreDump, logTmpUsage } from "../tmp-usage";
 
+const MAX_ENQUEUE_COUNT = 2000;
+
 const program = Effect.gen(function* () {
   yield* disableCoreDump;
   yield* cleanupTmp;
@@ -19,13 +21,17 @@ const program = Effect.gen(function* () {
   const enqueuedCountRef = yield* Ref.make(0);
 
   yield* paginatedJobNumbers().pipe(
-    Stream.runForEach((jobNumbers) =>
+    Stream.runForEachWhile((jobNumbers) =>
       Effect.gen(function* () {
         const unregistered = yield* filterUnregistered(jobNumbers);
         yield* Effect.forEach(unregistered, (jobNumber) =>
           queue.send({ jobNumber }),
         );
-        yield* Ref.update(enqueuedCountRef, (n) => n + unregistered.length);
+        const total = yield* Ref.updateAndGet(
+          enqueuedCountRef,
+          (n) => n + unregistered.length,
+        );
+        return total <= MAX_ENQUEUE_COUNT;
       }),
     ),
   );

--- a/apps/backend/collector/lib/job-number-crawler/crawl.ts
+++ b/apps/backend/collector/lib/job-number-crawler/crawl.ts
@@ -1,13 +1,5 @@
 import { JobNumber } from "@sho/models";
-import {
-  Data,
-  Effect,
-  Either,
-  Layer,
-  Option,
-  Schema,
-  Stream,
-} from "effect";
+import { Data, Effect, Either, Layer, Option, Schema, Stream } from "effect";
 import type { Locator } from "../browser";
 import type { DomainError, SystemError } from "../error";
 import {
@@ -193,11 +185,11 @@ export const paginatedJobNumbers = () =>
         jobSearchPage,
         config.jobSearchCriteria,
       );
-      return Stream.paginateEffect(undefined as void, () =>
+      return Stream.paginateEffect(null, () =>
         Effect.gen(function* () {
           const jobNumbers = yield* fetchJobNumbers(firstJobListPage);
           if (jobNumbers.length === 0) {
-            return [jobNumbers, Option.none<void>()] as const;
+            return [jobNumbers, Option.none<null>()] as const;
           }
           const hasNext = yield* isNextPageEnabled(firstJobListPage);
           if (hasNext) {
@@ -207,7 +199,7 @@ export const paginatedJobNumbers = () =>
           }
           return [
             jobNumbers,
-            hasNext ? Option.some<void>(undefined) : Option.none<void>(),
+            hasNext ? Option.some(null) : Option.none<null>(),
           ] as const;
         }),
       );

--- a/apps/backend/collector/lib/job-number-crawler/crawl.ts
+++ b/apps/backend/collector/lib/job-number-crawler/crawl.ts
@@ -1,6 +1,5 @@
 import { JobNumber } from "@sho/models";
 import {
-  Chunk,
   Data,
   Effect,
   Either,
@@ -9,7 +8,6 @@ import {
   Schema,
   Stream,
 } from "effect";
-import { filterUnregistered } from "../apiClient/query";
 import type { Locator } from "../browser";
 import type { DomainError, SystemError } from "../error";
 import {
@@ -139,32 +137,15 @@ const goToNextJobListPage = Effect.fn("goToNextJobListPage")(function* (
   yield* Effect.logDebug("navigated to next job list page.");
 });
 
-const fetchAndDedupeAndPaginateAndDelay = Effect.fn(
-  "fetchAndDedupeAndPaginateAndDelay",
-)(function* (page: JobListPage, count: number) {
-  const { roughMaxCount } = yield* JobNumberCrawlerConfig;
+const fetchJobNumbers = Effect.fn("fetchJobNumbers")(function* (
+  page: JobListPage,
+) {
   const jobOverviewList = yield* listJobOverviewElem(page);
   if (jobOverviewList.length === 0) {
     yield* Effect.logInfo("no job listings found on this page. finishing.");
-    return [Chunk.empty(), Option.none()] as const;
+    return [] as readonly JobNumber[];
   }
-  const jobNumbers = yield* extractJobNumbers(jobOverviewList);
-  const unregistered = yield* filterUnregistered(jobNumbers);
-
-  const chunked = Chunk.fromIterable(unregistered);
-  const tmpTotal = count + jobNumbers.length;
-  const nextPageEnabled = yield* isNextPageEnabled(page);
-  if (nextPageEnabled) {
-    yield* goToNextJobListPage(page).pipe(
-      Effect.andThen(Effect.sleep("2 seconds")),
-    );
-  }
-  return [
-    chunked,
-    nextPageEnabled && tmpTotal <= roughMaxCount
-      ? Option.some(tmpTotal)
-      : Option.none(),
-  ] as const;
+  return yield* extractJobNumbers(jobOverviewList);
 });
 
 // ============================================================
@@ -177,7 +158,6 @@ export class JobNumberCrawlerConfig extends Effect.Tag(
   JobNumberCrawlerConfig,
   {
     readonly jobSearchCriteria: JobSearchCriteria;
-    readonly roughMaxCount: number;
   }
 >() {
   static main = Layer.succeed(JobNumberCrawlerConfig, {
@@ -186,7 +166,6 @@ export class JobNumberCrawlerConfig extends Effect.Tag(
         occupationSelection: "ソフトウェア開発技術者、プログラマー",
       },
     },
-    roughMaxCount: 2000,
   });
   static dev = Layer.succeed(JobNumberCrawlerConfig, {
     jobSearchCriteria: {
@@ -194,7 +173,6 @@ export class JobNumberCrawlerConfig extends Effect.Tag(
         occupationSelection: "ソフトウェア開発技術者、プログラマー",
       },
     },
-    roughMaxCount: 50,
   });
 }
 
@@ -202,24 +180,36 @@ export class JobNumberCrawlerConfig extends Effect.Tag(
 // Crawler (Effect.fn — 手続き的オーケストレーション)
 // ============================================================
 
-export const crawlJobLinks = Effect.fn("crawlJobLinks")(function* () {
-  const config = yield* JobNumberCrawlerConfig;
-  yield* Effect.logInfo(
-    `building crawler: config=${JSON.stringify(config, null, 2)}`,
+export const paginatedJobNumbers = () =>
+  Stream.unwrap(
+    Effect.gen(function* () {
+      const config = yield* JobNumberCrawlerConfig;
+      yield* Effect.logInfo(
+        `building crawler: config=${JSON.stringify(config, null, 2)}`,
+      );
+      const jobSearchPage = yield* openJobSearchPage();
+      yield* Effect.logInfo("start crawling...");
+      const firstJobListPage = yield* navigateByCriteria(
+        jobSearchPage,
+        config.jobSearchCriteria,
+      );
+      return Stream.paginateEffect(undefined, () =>
+        Effect.gen(function* () {
+          const jobNumbers = yield* fetchJobNumbers(firstJobListPage);
+          if (jobNumbers.length === 0) {
+            return [jobNumbers, Option.none()] as const;
+          }
+          const hasNext = yield* isNextPageEnabled(firstJobListPage);
+          if (hasNext) {
+            yield* goToNextJobListPage(firstJobListPage).pipe(
+              Effect.andThen(Effect.sleep("2 seconds")),
+            );
+          }
+          return [
+            jobNumbers,
+            hasNext ? Option.some<void>(undefined) : Option.none(),
+          ] as const;
+        }),
+      );
+    }),
   );
-  const jobSearchPage = yield* openJobSearchPage();
-  yield* Effect.logInfo("start crawling...");
-  const firstJobListPage = yield* navigateByCriteria(
-    jobSearchPage,
-    config.jobSearchCriteria,
-  );
-  const stream = Stream.paginateChunkEffect(
-    0,
-    // 後で対処する
-    (count) => fetchAndDedupeAndPaginateAndDelay(firstJobListPage, count),
-  );
-  const chunk = yield* Stream.runCollect(stream);
-  const jobLinks = Chunk.toArray(chunk);
-  yield* Effect.logInfo(`crawling finished. total: ${jobLinks.length}`);
-  return jobLinks;
-});

--- a/apps/backend/collector/lib/job-number-crawler/crawl.ts
+++ b/apps/backend/collector/lib/job-number-crawler/crawl.ts
@@ -193,11 +193,11 @@ export const paginatedJobNumbers = () =>
         jobSearchPage,
         config.jobSearchCriteria,
       );
-      return Stream.paginateEffect(undefined, () =>
+      return Stream.paginateEffect(undefined as void, () =>
         Effect.gen(function* () {
           const jobNumbers = yield* fetchJobNumbers(firstJobListPage);
           if (jobNumbers.length === 0) {
-            return [jobNumbers, Option.none()] as const;
+            return [jobNumbers, Option.none<void>()] as const;
           }
           const hasNext = yield* isNextPageEnabled(firstJobListPage);
           if (hasNext) {
@@ -207,7 +207,7 @@ export const paginatedJobNumbers = () =>
           }
           return [
             jobNumbers,
-            hasNext ? Option.some<void>(undefined) : Option.none(),
+            hasNext ? Option.some<void>(undefined) : Option.none<void>(),
           ] as const;
         }),
       );

--- a/apps/backend/collector/lib/scripts/verify-job-number-crawler.ts
+++ b/apps/backend/collector/lib/scripts/verify-job-number-crawler.ts
@@ -1,16 +1,15 @@
-import { Effect, Logger, LogLevel } from "effect";
+import { Console, Effect, Logger, LogLevel, Stream } from "effect";
 import { APIConfig } from "../apiClient/config";
 import { ChromiumBrowserConfig } from "../browser";
 import {
-  crawlJobLinks,
   JobNumberCrawlerConfig,
+  paginatedJobNumbers,
 } from "../job-number-crawler/crawl";
 
 async function main() {
-  const program = Effect.scoped(
-    Effect.gen(function* () {
-      return yield* crawlJobLinks();
-    }),
+  const program = paginatedJobNumbers().pipe(
+    Stream.runForEach((unregistered) => Console.log(unregistered)),
+    Effect.scoped,
   );
 
   const runnable = program.pipe(
@@ -19,9 +18,7 @@ async function main() {
     Effect.provide(ChromiumBrowserConfig.dev),
     Logger.withMinimumLogLevel(LogLevel.Debug),
   );
-  Effect.runPromise(runnable).then((jobNumbers) =>
-    console.dir({ jobNumbers }, { depth: null }),
-  );
+  await Effect.runPromise(runnable);
 }
 
 main();


### PR DESCRIPTION
## Summary
- `crawlJobLinks` を `paginatedJobNumbers` (`Stream<readonly JobNumber[]>`) に変更。ページ単位で未加工の JobNumber 配列を emit し、重複チェック (`filterUnregistered`)・キュー送信・件数カウントは handler 側で per-page 処理する形に再構成
- crawler 内の `roughMaxCount` 打ち切りを削除し、handler 側で `Stream.runForEachWhile` + `Ref` により累計 2000 件超過で Stream を pull 停止するセーフガードに集約

## Test plan
- [ ] `pnpm -C apps/backend/collector type-check`
- [ ] `pnpm -C apps/backend/collector test`
- [ ] ローカル E2E (`pnpm dev:e2e`) で crawler → SQS → ETL が通ることを確認
- [ ] 累計 ≤ 2000 で打ち切られることをログで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)