### PR TITLE
fix(collector): 本番クローラー Lambda の起動時 Die を解消

### DIFF
--- a/apps/backend/collector/infra/functions/job-detail-handler/handler.ts
+++ b/apps/backend/collector/infra/functions/job-detail-handler/handler.ts
@@ -3,7 +3,7 @@ import type { SQSEvent } from "aws-lambda";
 import { Effect, Schema } from "effect";
 import {
   ChromiumBrowserConfig,
-  DebugDumpConfig,
+  DebugMode,
 } from "../../../lib/hellowork/browser";
 import {
   JobDetailExtractor,
@@ -52,7 +52,7 @@ const processJobDetail = (jobNumber: string) => {
     Effect.provide(JobDetailTransformer.Default),
     Effect.provide(JobDetailLoader.main),
     Effect.provide(ChromiumBrowserConfig.lambda),
-    Effect.provide(DebugDumpConfig.noop),
+    Effect.provide(DebugMode.main),
     Effect.provide(LoggerLayer),
     Effect.orDie,
   );

--- a/apps/backend/collector/infra/functions/job-number-handler/handler.ts
+++ b/apps/backend/collector/infra/functions/job-number-handler/handler.ts
@@ -3,7 +3,7 @@ import { APIConfig } from "../../../lib/apiClient/config";
 import { filterUnregistered } from "../../../lib/apiClient/query";
 import {
   ChromiumBrowserConfig,
-  DebugDumpConfig,
+  DebugMode,
 } from "../../../lib/hellowork/browser";
 import {
   CrawlerConfig,
@@ -57,7 +57,7 @@ const runnable = program.pipe(
   Effect.provide(CrawlerConfig.main),
   Effect.provide(SearchConfig.detailed),
   Effect.provide(ChromiumBrowserConfig.lambda),
-  Effect.provide(DebugDumpConfig.noop),
+  Effect.provide(DebugMode.main),
   Effect.provide(JobDetailQueueConfig.main),
   Effect.provide(LoggerLayer),
   Effect.orDie,

--- a/apps/backend/collector/lib/hellowork/browser.ts
+++ b/apps/backend/collector/lib/hellowork/browser.ts
@@ -55,26 +55,17 @@ export class ChromiumBrowserConfig extends Context.Tag("ChromiumBrowserConfig")<
   } satisfies LaunchOptions);
 }
 
-// ── DebugDumpConfig (Context.Tag — 失敗時 dump 設定) ──
+// ── DebugMode (Context.Tag — true なら openBrowserPage が失敗時に dump する) ──
 
-export class DebugDumpConfig extends Context.Tag("DebugDumpConfig")<
-  DebugDumpConfig,
-  { readonly dir: string }
->() {
-  /** 未実装マーカ — provide すると die する。環境ごとに dev/本番用 Layer に差し替える。 */
-  static noop = Layer.effect(
-    DebugDumpConfig,
-    Effect.dieMessage("DebugDumpConfig.noop: not implemented"),
-  );
-  /** 開発・検証用。`.debug/` に dump。 */
-  static dev = Layer.succeed(DebugDumpConfig, { dir: ".debug" });
+export class DebugMode extends Context.Tag("DebugMode")<DebugMode, boolean>() {
+  static dev = Layer.succeed(DebugMode, true);
+  static main = Layer.succeed(DebugMode, false);
 }
 
-// ── Debug helper: browser 内の全 page の HTML + screenshot を dump ──
+// ── dumpBrowserPage (browser 内の全 page の HTML + screenshot を dir 配下に dump) ──
 
-const dumpBrowserPages = (browser: Browser) =>
+export const dumpBrowserPage = (browser: Browser, dir: string) =>
   Effect.gen(function* () {
-    const { dir } = yield* DebugDumpConfig;
     const pages = browser.contexts().flatMap((ctx) => ctx.pages());
     const stamp = new Date().toISOString().replace(/[:.]/g, "-");
     yield* Effect.promise(() => mkdir(dir, { recursive: true }));
@@ -99,6 +90,7 @@ const dumpBrowserPages = (browser: Browser) =>
 
 export const openBrowserPage = Effect.fn("openBrowserPage")(function* () {
   const config = yield* ChromiumBrowserConfig;
+  const debugMode = yield* DebugMode;
   yield* Console.log("launching chromium browser...");
   const browser = yield* Effect.acquireRelease(
     Effect.tryPromise({
@@ -116,7 +108,9 @@ export const openBrowserPage = Effect.fn("openBrowserPage")(function* () {
   );
   // 失敗時のみ dump（finalizer は LIFO なので close より前に走る）
   yield* Effect.addFinalizer((exit) =>
-    Exit.isFailure(exit) ? dumpBrowserPages(browser) : Effect.void,
+    Exit.isFailure(exit) && debugMode
+      ? dumpBrowserPage(browser, ".debug")
+      : Effect.void,
   );
   yield* Console.log("browser launched, creating context...");
   const context = yield* Effect.tryPromise({

--- a/apps/backend/collector/lib/hellowork/scripts/dump-job-detail.ts
+++ b/apps/backend/collector/lib/hellowork/scripts/dump-job-detail.ts
@@ -8,7 +8,7 @@
 
 import type { JobNumber } from "@sho/models";
 import { Effect, Logger, LogLevel } from "effect";
-import { ChromiumBrowserConfig, DebugDumpConfig } from "../browser";
+import { ChromiumBrowserConfig, DebugMode } from "../browser";
 import { navigateByJobNumber, openJobSearchPage } from "../page/search";
 
 const jobNumber = (process.argv[2] ?? "13010-35021361") as JobNumber;
@@ -48,7 +48,7 @@ async function main() {
 
   const runnable = program.pipe(
     Effect.provide(ChromiumBrowserConfig.dev),
-    Effect.provide(DebugDumpConfig.dev),
+    Effect.provide(DebugMode.dev),
     Effect.scoped,
     Logger.withMinimumLogLevel(LogLevel.Debug),
   );

--- a/apps/backend/collector/lib/hellowork/scripts/dump-search-result.ts
+++ b/apps/backend/collector/lib/hellowork/scripts/dump-search-result.ts
@@ -6,7 +6,7 @@
  */
 
 import { Effect, Logger, LogLevel } from "effect";
-import { ChromiumBrowserConfig, DebugDumpConfig } from "../browser";
+import { ChromiumBrowserConfig, DebugMode } from "../browser";
 import { navigateByCriteria, openJobSearchPage } from "../page/search";
 
 async function main() {
@@ -55,7 +55,7 @@ async function main() {
 
   const runnable = program.pipe(
     Effect.provide(ChromiumBrowserConfig.dev),
-    Effect.provide(DebugDumpConfig.dev),
+    Effect.provide(DebugMode.dev),
     Logger.withMinimumLogLevel(LogLevel.Debug),
   );
   await Effect.runPromise(runnable);

--- a/apps/backend/collector/lib/hellowork/scripts/verify-detail-search.ts
+++ b/apps/backend/collector/lib/hellowork/scripts/verify-detail-search.ts
@@ -14,7 +14,7 @@
  */
 
 import { Effect, Logger, LogLevel } from "effect";
-import { ChromiumBrowserConfig, DebugDumpConfig } from "../browser";
+import { ChromiumBrowserConfig, DebugMode } from "../browser";
 import {
   navigateByCriteria,
   navigateToDetailedJobSearchPage,
@@ -52,7 +52,7 @@ async function main() {
 
   const runnable = program.pipe(
     Effect.provide(ChromiumBrowserConfig.dev),
-    Effect.provide(DebugDumpConfig.dev),
+    Effect.provide(DebugMode.dev),
     Logger.withMinimumLogLevel(LogLevel.Debug),
   );
   await Effect.runPromise(runnable);

--- a/apps/backend/collector/lib/hellowork/scripts/verify-job-detail-crawler.ts
+++ b/apps/backend/collector/lib/hellowork/scripts/verify-job-detail-crawler.ts
@@ -1,6 +1,6 @@
 import type { JobNumber } from "@sho/models";
 import { Effect, Logger, LogLevel } from "effect";
-import { ChromiumBrowserConfig, DebugDumpConfig } from "../browser";
+import { ChromiumBrowserConfig, DebugMode } from "../browser";
 import {
   JobDetailExtractor,
   JobDetailLoader,
@@ -20,7 +20,7 @@ async function main() {
     Effect.provide(JobDetailTransformer.Default),
     Effect.provide(JobDetailLoader.noop),
     Effect.provide(ChromiumBrowserConfig.dev),
-    Effect.provide(DebugDumpConfig.dev),
+    Effect.provide(DebugMode.dev),
     Effect.scoped,
     Logger.withMinimumLogLevel(LogLevel.Debug),
   );

--- a/apps/backend/collector/lib/hellowork/scripts/verify-job-number-crawler.ts
+++ b/apps/backend/collector/lib/hellowork/scripts/verify-job-number-crawler.ts
@@ -1,5 +1,5 @@
 import { Console, Effect, Logger, LogLevel, Ref, Stream } from "effect";
-import { ChromiumBrowserConfig, DebugDumpConfig } from "../browser";
+import { ChromiumBrowserConfig, DebugMode } from "../browser";
 import {
   CrawlerConfig,
   paginatedJobNumbers,
@@ -29,7 +29,7 @@ async function main() {
     Effect.provide(CrawlerConfig.dev),
     Effect.provide(SearchConfig.simple),
     Effect.provide(ChromiumBrowserConfig.dev),
-    Effect.provide(DebugDumpConfig.dev),
+    Effect.provide(DebugMode.dev),
     Logger.withMinimumLogLevel(LogLevel.Debug),
   );
   await Effect.runPromise(runnable);


### PR DESCRIPTION
## Summary
本番 `job-number-crawler` / `job-detail-etl` Lambda が起動直後 45ms で毎回 Die していたバグを修正。`DebugDumpConfig` を撤去し、boolean を持つ `DebugMode` Context.Tag に置き換えた。

## Background & Motivation

2026-04-30 16:00 UTC（5/1 01:00 JST）以降、本番クローラーパイプラインがデータをまったく更新していなかった。`/crawler-diagnose` で確認したところ:

- EventBridge は ENABLED、SQS / Lambda 状態も正常に見えた
- だが `job-number-crawler` のログを見ると、毎起動で同じ RequestId に対して `START → ERROR → END → REPORT` が 3 回繰り返されていた（Lambda の async 自動リトライによる 1 + 2 = 3 回起動）

エラー本体:

```json
{"_tag":"Die","defect":{"_tag":"RuntimeException","message":"DebugDumpConfig.noop: not implemented"}}
```

直近の #915 (`refactor(collector): lib/hellowork 配下に再編 + 詳細検索対応 + Config 整理`) で `DebugDumpConfig` を切り出した際、本番用の no-op 実装を後回しにした「未実装プレースホルダ」が残っていた:

```ts
// 旧 browser.ts
static noop = Layer.effect(
  DebugDumpConfig,
  Effect.dieMessage("DebugDumpConfig.noop: not implemented"),
);
```

handler が `provide(DebugDumpConfig.noop)` していたため、Lambda が起動するたびに即 Die → 求人番号がまったく SQS に投入されず → 詳細 ETL も走らず → DB 更新ゼロ、という連鎖だった。

加えて `/crawler-diagnose` の ETL ログ確認スクリプト (`check-job-detail-etl-logs.sh`) が `/aws/lambda/job-detail-etl` ロググループしか見ていなかったため、上流の crawler 側で死んでいる事象を取りこぼしていた（別 PR で対応予定）。

## Design Decisions

### `DebugDumpConfig` の撤去と `DebugMode` (boolean Context.Tag) への置き換え

会話の中で複数の代替案を順に検討して棄却した:

1. **interface を `{ dir: string | null }` にして null = no-op** — null sentinel が「変」だとなった
2. **`Effect.serviceOption` で optional 依存にし `noop` Layer を消す** — 「`noop` を明示的に provide したい」という意図と合わない
3. **`Debugger` Context.Tag にメソッド (`dumpBrowserPage`) を持たせ、`Debugger.main` / `Debugger.noop` の Layer を切り替え** — `openBrowserPage` 内で `yield* Debugger` するのが「設定値 1 個取りに行くだけのために Service 取得する」感じで重く感じた
4. **finalizer 自体を `openBrowserPage` から削除し、必要な人が自前で `dumpBrowserPage(browser, dir)` を呼ぶ** — `browser` インスタンスを呼び出し側に晒す API 拡張が必要
5. **採用: `DebugMode` (boolean) Context.Tag** — `dev = true` / `main = false` で、`openBrowserPage` の finalizer 内で boolean 判定して `dumpBrowserPage` を呼ぶ／呼ばない

### `DebugMode` を採用した理由

- **null/sentinel 不要**: `boolean` という素直な値だけで「dump する／しない」を表現できる
- **「provide 忘れ」が型エラーで弾かれる**: 必須依存になっているので、未実装プレースホルダ Layer をそのままデプロイしてしまう今回の事故が**型レベルで防げる**
- **`Layer.succeed` で完結**: `Layer.effect(..., Effect.dieMessage(...))` のような未実装マーカが入る余地がない（次の人がプレースホルダを残してしまう余地を消した）
- **`dumpBrowserPage(browser, dir)` は素の export 関数として残した**: `openBrowserPage` の finalizer は `dir` を `.debug` で固定して呼ぶが、変えたい人は直接呼べる

## Changes

### `apps/backend/collector/lib/hellowork/browser.ts`
- `DebugDumpConfig` Context.Tag（および未実装プレースホルダの `noop` Layer）を削除
- `DebugMode` Context.Tag を追加（値は `boolean`）
  - `DebugMode.dev = Layer.succeed(DebugMode, true)`
  - `DebugMode.main = Layer.succeed(DebugMode, false)`
- 旧 finalizer 内のインライン `dumpBrowserPages` を `dumpBrowserPage(browser, dir)` という export 関数に切り出し
- `openBrowserPage` の finalizer を `DebugMode` の boolean で条件分岐:
  ```ts
  yield* Effect.addFinalizer((exit) =>
    Exit.isFailure(exit) && debugMode
      ? dumpBrowserPage(browser, ".debug")
      : Effect.void,
  );
  ```

### `apps/backend/collector/infra/functions/job-number-handler/handler.ts`
### `apps/backend/collector/infra/functions/job-detail-handler/handler.ts`
- `DebugDumpConfig` の import / `provide` を削除
- `DebugMode.main`（= false、dump スキップ）の `provide` を追加
- これにより本番 Lambda は起動時に Die しなくなる

### `apps/backend/collector/lib/hellowork/scripts/`（5 ファイル）
- `dump-search-result.ts`, `verify-detail-search.ts`, `dump-job-detail.ts`, `verify-job-detail-crawler.ts`, `verify-job-number-crawler.ts`
- `DebugDumpConfig.dev` の `provide` を `DebugMode.dev`（= true、`.debug/` に dump）に置き換え

## Test Plan

- [x] `pnpm --filter collector type-check` 通過
- [x] `pnpm --filter collector test` 通過（既存テスト）
- [ ] **本番デプロイ後の手動確認**: `aws lambda invoke` で `job-number-crawler` を手動起動し、Die せず正常完了して SQS にメッセージが投入されることを確認する
  - EventBridge の次回スケジュールは 2026-05-04 01:00 JST（土曜の夜＝日曜 16:00 UTC）。それまで放置すると最大 2 日 DB 更新が止まったままになるので、手動 invoke 推奨
- [ ] CI: `pr-checks.yml` 通過

## 関連
- 起源: #915 (`refactor(collector): lib/hellowork 配下に再編 + 詳細検索対応 + Config 整理`)
- 後続 TODO: `/crawler-diagnose` の `check-job-detail-etl-logs.sh` を crawler 側のロググループも見るように拡張する（今回の障害を取りこぼした原因）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
