### PR TITLE
feat(collector): ナビゲーション後にページを dump する debug フックを追加

### DIFF
--- a/apps/backend/collector/lib/hellowork/browser.ts
+++ b/apps/backend/collector/lib/hellowork/browser.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { Console, Context, Data, Effect, Exit, Layer } from "effect";
-import type { Browser, LaunchOptions } from "playwright-core";
+import type { Browser, LaunchOptions, Page } from "playwright-core";
 import { chromium } from "playwright-core";
 import type { SystemError } from "../error";
 
@@ -55,42 +55,77 @@ export class ChromiumBrowserConfig extends Context.Tag("ChromiumBrowserConfig")<
   } satisfies LaunchOptions);
 }
 
-// ── DebugMode (Context.Tag — true なら openBrowserPage が失敗時に dump する) ──
+// ── DebugMode (Context.Tag — enabled なら dumpPage / dumpBrowserPage が dir に dump する) ──
+// dev では .debug/run-{stamp}/ をその run 用のサブディレクトリとして払い出し、
+// 同じ run のダンプが時系列で 1 箇所にまとまるようにする。
 
-export class DebugMode extends Context.Tag("DebugMode")<DebugMode, boolean>() {
-  static dev = Layer.succeed(DebugMode, true);
-  static main = Layer.succeed(DebugMode, false);
+export type DebugModeValue =
+  | { readonly enabled: false }
+  | { readonly enabled: true; readonly dir: string };
+
+export class DebugMode extends Context.Tag("DebugMode")<
+  DebugMode,
+  DebugModeValue
+>() {
+  static dev = Layer.sync(DebugMode, () => {
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    return {
+      enabled: true,
+      dir: resolve(".debug", `run-${stamp}`),
+    } as const;
+  });
+  static main = Layer.succeed(DebugMode, {
+    enabled: false,
+  } satisfies DebugModeValue);
 }
 
-// ── dumpBrowserPage (browser 内の全 page の HTML + screenshot を dir 配下に dump) ──
+// ── dumpPage (1 枚の Page を dir 配下に HTML + screenshot で dump) ──
+// label にどのページか分かる短い名前を渡す。ファイル名は `{stamp}-{label}.{html,png}`。
 
-export const dumpBrowserPage = (browser: Browser, dir: string) =>
-  Effect.gen(function* () {
-    const pages = browser.contexts().flatMap((ctx) => ctx.pages());
-    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
-    yield* Effect.promise(() => mkdir(dir, { recursive: true }));
-    yield* Effect.forEach(pages, (page, i) => {
-      const base = resolve(dir, `on-error-${stamp}-${i}`);
-      return Effect.tryPromise({
+const dumpPageToDir = (page: Page, dir: string, label: string) => {
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const safeLabel = label.replace(/[^a-zA-Z0-9_-]/g, "_");
+  const base = resolve(dir, `${stamp}-${safeLabel}`);
+  return Effect.promise(() => mkdir(dir, { recursive: true })).pipe(
+    Effect.andThen(
+      Effect.tryPromise({
         try: async () => {
           await writeFile(`${base}.html`, await page.content());
           await page.screenshot({ path: `${base}.png`, fullPage: true });
         },
         catch: (e) => e,
-      }).pipe(
-        Effect.andThen(Console.log(`dumped ${base}.{html,png}`)),
-        Effect.catchAll((e) =>
-          Console.error(`dump failed for ${base}: ${String(e)}`),
-        ),
-      );
-    });
+      }),
+    ),
+    Effect.andThen(Console.log(`dumped ${base}.{html,png}`)),
+    Effect.catchAll((e) =>
+      Console.error(`dump failed for ${base}: ${String(e)}`),
+    ),
+  );
+};
+
+export const dumpPage = (page: Page, label: string) =>
+  Effect.gen(function* () {
+    const debug = yield* DebugMode;
+    if (!debug.enabled) return;
+    yield* dumpPageToDir(page, debug.dir, label);
+  });
+
+// ── dumpBrowserPage (browser 内の全 page を一斉に dump) ──
+
+export const dumpBrowserPage = (browser: Browser, label: string) =>
+  Effect.gen(function* () {
+    const debug = yield* DebugMode;
+    if (!debug.enabled) return;
+    const pages = browser.contexts().flatMap((ctx) => ctx.pages());
+    yield* Effect.forEach(pages, (page, i) =>
+      dumpPageToDir(page, debug.dir, `${label}-${i}`),
+    );
   });
 
 // ── openBrowserPage (Effect.fn) ──
 
 export const openBrowserPage = Effect.fn("openBrowserPage")(function* () {
   const config = yield* ChromiumBrowserConfig;
-  const debugMode = yield* DebugMode;
   yield* Console.log("launching chromium browser...");
   const browser = yield* Effect.acquireRelease(
     Effect.tryPromise({
@@ -108,9 +143,7 @@ export const openBrowserPage = Effect.fn("openBrowserPage")(function* () {
   );
   // 失敗時のみ dump（finalizer は LIFO なので close より前に走る）
   yield* Effect.addFinalizer((exit) =>
-    Exit.isFailure(exit) && debugMode
-      ? dumpBrowserPage(browser, ".debug")
-      : Effect.void,
+    Exit.isFailure(exit) ? dumpBrowserPage(browser, "on-error") : Effect.void,
   );
   yield* Console.log("browser launched, creating context...");
   const context = yield* Effect.tryPromise({

--- a/apps/backend/collector/lib/hellowork/job-detail-crawler/extractor.ts
+++ b/apps/backend/collector/lib/hellowork/job-detail-crawler/extractor.ts
@@ -1,7 +1,7 @@
 import type { JobNumber } from "@sho/models";
 import { Data, Effect, Schema } from "effect";
 import type { DomainError, SystemError } from "../../error";
-import type { Page } from "../browser";
+import { dumpPage, type Page } from "../browser";
 import type { FirstJobListPage } from "../job-number-crawler/type";
 import type { JobDetailPage } from "../page/detail";
 import { navigateByJobNumber, openJobSearchPage } from "../page/search";
@@ -233,6 +233,7 @@ function goToSingleJobDetailPage(page: FirstJobListPage) {
         }),
     });
     yield* Effect.logDebug("navigated to job detail page from job list page.");
+    yield* dumpPage(page, "job-detail-page");
     const _page: Page = page;
     return _page as JobDetailPage;
   });

--- a/apps/backend/collector/lib/hellowork/job-number-crawler/crawl.ts
+++ b/apps/backend/collector/lib/hellowork/job-number-crawler/crawl.ts
@@ -11,7 +11,7 @@ import {
 } from "effect";
 import type { DomainError, SystemError } from "../../error";
 import { formatParseError } from "../../util";
-import type { Locator } from "../browser";
+import { dumpPage, type Locator } from "../browser";
 import {
   type DetailedJobSearchCriteria,
   navigateByCriteria as detailedNavigateByCriteria,
@@ -141,6 +141,7 @@ const goToNextJobListPage = Effect.fn("goToNextJobListPage")(function* (
       }),
   });
   yield* Effect.logDebug("navigated to next job list page.");
+  yield* dumpPage(page, "job-list-next-page");
 });
 
 const fetchJobNumbers = Effect.fn("fetchJobNumbers")(function* (

--- a/apps/backend/collector/lib/hellowork/page/detail-search.ts
+++ b/apps/backend/collector/lib/hellowork/page/detail-search.ts
@@ -1,6 +1,6 @@
 import type { JobNumber } from "@sho/models";
 import { Effect } from "effect";
-import type { Page } from "../browser";
+import { dumpPage, type Page } from "../browser";
 import { PageActionError } from "../errors";
 import type { FirstJobListPage } from "../job-number-crawler/type";
 import type { SimpleJobSearchPage } from "./search";
@@ -121,6 +121,7 @@ const clickSearchBtn = Effect.fn("clickSearchBtn")(function* (
   yield* Effect.logDebug(
     "navigated to job list page from detailed job search page.",
   );
+  yield* dumpPage(page, "job-list-by-criteria-detailed");
 });
 
 // ============================================================
@@ -148,6 +149,7 @@ export const navigateToDetailedJobSearchPage = Effect.fn(
       }),
   });
   yield* Effect.logDebug("navigated to detailed job search page.");
+  yield* dumpPage(page, "detailed-job-search-page");
   const _page: Page = page;
   return _page as DetailedJobSearchPage;
 });

--- a/apps/backend/collector/lib/hellowork/page/search.ts
+++ b/apps/backend/collector/lib/hellowork/page/search.ts
@@ -1,6 +1,6 @@
 import type { JobNumber } from "@sho/models";
 import { Effect } from "effect";
-import { openBrowserPage, type Page } from "../browser";
+import { dumpPage, openBrowserPage, type Page } from "../browser";
 import { InvalidJobNumberFormatError, PageActionError } from "../errors";
 import type { FirstJobListPage } from "../job-number-crawler/type";
 
@@ -75,6 +75,7 @@ const clickSearchNoBtn = Effect.fn("clickSearchNoBtn")(function* (
       }),
   });
   yield* Effect.logDebug("navigated to job list page from job search page.");
+  yield* dumpPage(page, "job-list-by-job-number");
 });
 
 const clickSearchBtn = Effect.fn("clickSearchBtn")(function* (
@@ -94,6 +95,7 @@ const clickSearchBtn = Effect.fn("clickSearchBtn")(function* (
       }),
   });
   yield* Effect.logDebug("navigated to job list page from job search page.");
+  yield* dumpPage(page, "job-list-by-criteria-simple");
 });
 
 // ============================================================
@@ -114,6 +116,7 @@ export const openJobSearchPage = Effect.fn("openJobSearchPage")(function* () {
       }),
   });
   yield* Effect.logDebug("navigated to job search page.");
+  yield* dumpPage(page, "simple-job-search-page");
   return page as SimpleJobSearchPage;
 });
 


### PR DESCRIPTION
## Summary

Collector の `DebugMode` を判別可能 union 化し、`dumpPage(page, label)` を新設。各ページナビゲーション直後で呼び出し、`.debug/run-{ISO-stamp}/` 配下に HTML+screenshot を保存できるようにした。

## Background & Motivation

クローラーが本番で予期せぬ DOM 構造に出会って失敗したとき、現状は `openBrowserPage` の finalizer が「失敗時に最後の 1 ページだけ」をダンプする仕組みしかなく、どの段階のナビゲーションで構造が崩れたかを特定しづらかった。検索ページ → 詳細検索 → 求人一覧 → 求人詳細 → 次ページ送りと多段ナビゲーションが続くため、各ステップの「いつ」「どのページが」どうなっていたかを後から追える状態にしたい。

セレクタ調査用のスクリプト（`pnpm dev:dump-html` 等）はあるが、実パイプラインのフロー上で何が起きたかは別問題で、これは恒常的な debug フックとして欲しい。本番 Lambda（`DebugMode.main`）では従来通り I/O ゼロを保つ前提。

## Design Decisions

### `DebugMode` の意味を「on/off + dump 先」に拡張

- 何を選んだか: `Context.Tag<DebugMode, boolean>` を `{ enabled: false } | { enabled: true; dir: string }` の判別可能 union に変更。`dev` は `Layer.sync` で run ごとに `.debug/run-{ISO-stamp}/` を払い出し、`main` は `enabled: false` で no-op。
- なぜ: ダンプ先ディレクトリも DebugMode に同梱することで、（a）「DebugMode を提供している = ダンプ可能」が型で表現できる、（b）run ごとの sub-directory を 1 箇所で決めて全 dump 関数が共有でき、1 セッションのダンプが時系列で 1 ディレクトリに揃う、（c）ダンプ関数側に dir 引数を持ち回さなくていい。
- 棄却案: `DebugDumpDir` を別 Tag にして合成する案。「DebugMode を提供したけど DebugDumpDir を忘れた」という事故が増えるだけで、今のところ DebugMode が欲しい場面 = ダンプも欲しい場面なので別 Tag にする利点がない。#915 で同種の半端な Layer 不在事故が起きた経緯（→ #920 で boolean 化）もあり、ここでも 1 Tag に閉じ込める方向で揃えた。

### `dumpPage` を per-navigation の単一 Page ダンプに

- 何を選んだか: `dumpPage(page: Page, label: string)` を新規追加。`DebugMode.enabled` が false なら no-op。enabled なら `{ISO-stamp}-{sanitized-label}.{html,png}` で 1 枚書き出す。既存の `dumpBrowserPage` も同じ `DebugMode` を読むよう書き直し、失敗 finalizer の dump 先を同じ run dir に統一。
- なぜ: 失敗時の一斉ダンプ（`dumpBrowserPage`）と、ナビゲーション中の中間ダンプ（`dumpPage`）は粒度が違うので、関数を分けた方が呼び側で意図が明確。両方が同じ `DebugMode.dir` を読むので、failure 時のダンプと navigation 経過のダンプが同じディレクトリに並び、時系列で見直せる。
- ファイル名規約: `{ISO-stamp}-{label}.{html,png}`。stamp が ISO 8601 のため lexicographic にソートすると時系列順になり、`label` でどのページか分かる。`label` は `[^a-zA-Z0-9_-]` を `_` に置換しておりパストラバーサル不可。

### 挿入箇所はすべて URL が変わる箇所のみ

- 何を選んだか: 「ページナビゲーション直後」だけにダンプ呼び出しを入れた。モーダルを開く click 等（職業選択モーダル展開など）には入れていない。
- なぜ: ユーザー要件「ページナビゲーションするたびに」に合致。中間 click まで全部ダンプすると `.debug` が爆発するし、`{label}.html` で相互比較するときノイズになる。

## Changes

### `apps/backend/collector/lib/hellowork/browser.ts`

- `DebugMode` Tag の値型を `boolean` から `DebugModeValue`（`{ enabled: false } | { enabled: true; dir }`）に変更
- `DebugMode.dev` を `Layer.sync` 化、`.debug/run-{ISO-stamp}/` を毎回新規に払い出し
- `dumpPageToDir(page, dir, label)` 内部ヘルパ追加（mkdir + writeFile + screenshot + Console.log + catchAll）
- `dumpPage(page, label)` 公開関数追加。DebugMode を読み、disabled なら no-op
- `dumpBrowserPage` を `(browser, label)` シグネチャに変更し、DebugMode を読むよう内部化
- `openBrowserPage` の finalizer を `dumpBrowserPage(browser, "on-error")` だけに整理（DebugMode の enable 判定は dump 関数側に集約）

### `apps/backend/collector/lib/hellowork/page/search.ts`

- `openJobSearchPage`: `page.goto` 後に `dumpPage(page, "simple-job-search-page")`
- `clickSearchNoBtn`（求人番号で検索）: 遷移後に `dumpPage(page, "job-list-by-job-number")`
- `clickSearchBtn`（職種で検索）: 遷移後に `dumpPage(page, "job-list-by-criteria-simple")`

### `apps/backend/collector/lib/hellowork/page/detail-search.ts`

- `navigateToDetailedJobSearchPage`: 遷移後に `dumpPage(page, "detailed-job-search-page")`
- `clickSearchBtn`（詳細検索）: 遷移後に `dumpPage(page, "job-list-by-criteria-detailed")`

### `apps/backend/collector/lib/hellowork/job-detail-crawler/extractor.ts`

- `goToSingleJobDetailPage`: 詳細遷移後に `dumpPage(page, "job-detail-page")`

### `apps/backend/collector/lib/hellowork/job-number-crawler/crawl.ts`

- `goToNextJobListPage`: 次ページ遷移後に `dumpPage(page, "job-list-next-page")`

## Test Plan

- [x] `pnpm exec biome check --write <staged>` 通過
- [x] `pnpm exec tsc --noEmit`（collector）通過
- [x] `pnpm test`（vitest, transformer.test.ts）通過
- [x] `DebugMode.main` 経路は no-op（`if (!debug.enabled) return;` で I/O 発生しない）であること、レビューで確認
- [ ] CI（`pr-checks.yml`）で build / type-check / test / lint
- [ ] dev 環境で `pnpm dev:verify-job-detail-crawler` を実走して `.debug/run-*/` に各ページの html+png が時系列で並ぶことを目視確認（フォロー）

## Notes

- `DebugMode.main` は `enabled: false` のみで I/O ゼロのため、本番 Lambda の挙動・性能・/tmp 使用量には影響なし
- `.debug/` は `.gitignore` 既存、漏洩リスクなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
